### PR TITLE
feat: add astro.config.mjs for Starlight theme configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,45 @@
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+import react from '@astrojs/react';
+import remarkMermaid from './src/plugins/remark-mermaid.mjs';
+
+const title = process.env.DOCS_TITLE || 'Documentation';
+const site = process.env.DOCS_SITE || 'https://robinmordasiewicz.github.io';
+const base = process.env.DOCS_BASE || '/';
+
+export default defineConfig({
+  site,
+  base,
+  markdown: {
+    remarkPlugins: [remarkMermaid],
+  },
+  integrations: [
+    starlight({
+      title,
+      customCss: [
+        './theme/fonts/font-face.css',
+        './theme/styles/custom.css',
+      ],
+      logo: {
+        src: './theme/assets/f5-logo.svg',
+      },
+      components: {
+        Footer: './theme/components/Footer.astro',
+      },
+      social: [
+        {
+          label: 'GitHub',
+          icon: 'github',
+          href: `https://github.com/${process.env.GITHUB_REPOSITORY || ''}`,
+        },
+      ],
+      sidebar: [
+        {
+          label: process.env.SIDEBAR_LABEL || 'Guide',
+          autogenerate: { directory: '/' },
+        },
+      ],
+    }),
+    react(),
+  ],
+});


### PR DESCRIPTION
## Summary
- Add `astro.config.mjs` to the theme repo so marketing can control Astro/Starlight branding configuration
- Identical content from f5xc-docs-builder — all relative paths resolve at build time when copied into the builder root

Closes #1

## Test plan
- [ ] Verify file contents match f5xc-docs-builder's current astro.config.mjs
- [ ] After PR2 (workflow update) merges, trigger a downstream docs build to confirm config is picked up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)