### PR TITLE
feat: add bugs URL to package.json for npm registry metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/robinmordasiewicz/f5xc-docs-theme"
   },
+  "bugs": {
+    "url": "https://github.com/robinmordasiewicz/f5xc-docs-theme/issues"
+  },
   "exports": {
     ".": "./index.ts",
     "./fonts/font-face.css": "./fonts/font-face.css",


### PR DESCRIPTION
## Summary
- Adds `bugs.url` field to `package.json` pointing to GitHub Issues
- Completes npm registry metadata (homepage, repository, bugs)
- Triggers first scoped package release as `@robinmordasiewicz/f5xc-docs-theme`

Closes #22

## Test plan
- [ ] Verify release workflow triggers on merge
- [ ] Verify `@robinmordasiewicz/f5xc-docs-theme` appears on npm
- [ ] Verify GitHub Release is created with changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)