### PR TITLE
fix: update enforce workflow reusable reference

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   enforce:
-    uses: robinmordasiewicz/f5xc-template/.github/workflows/enforce-repo-settings-reusable.yml@main
+    uses: robinmordasiewicz/f5xc-template/.github/workflows/enforce-repo-settings.yml@main
     secrets:
       repo-admin-token: ${{ secrets.REPO_ADMIN_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix broken `uses:` reference in `enforce-repo-settings.yml` from deleted `enforce-repo-settings-reusable.yml` to `enforce-repo-settings.yml`
- The reusable workflow was renamed in the template repo (commit 60458ef, PR #25) but downstream repos were not updated

## Test plan

- [ ] PR CI checks pass
- [ ] After merge, `gh workflow run enforce-repo-settings.yml` succeeds
- [ ] All 8 enforcement phases pass

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)