### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ dist/
 .env.*
 *.log
 .astro/
-astro.config.mjs


### PR DESCRIPTION
Closes #32

Synced managed files from `robinmordasiewicz/f5xc-template` canonical source:

- .gitignore