### PR TITLE
fix: wire remark-mermaid plugin and fix sidebar autogenerate directory

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,10 +2,14 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import react from '@astrojs/react';
 import f5xcDocsTheme from 'f5xc-docs-theme';
+import remarkMermaid from './src/plugins/remark-mermaid.mjs';
 
 export default defineConfig({
   site: process.env.DOCS_SITE || 'https://robinmordasiewicz.github.io',
   base: process.env.DOCS_BASE || '/',
+  markdown: {
+    remarkPlugins: [remarkMermaid],
+  },
   integrations: [
     starlight({
       title: process.env.DOCS_TITLE || 'Documentation',
@@ -23,7 +27,7 @@ export default defineConfig({
       sidebar: [
         {
           label: process.env.SIDEBAR_LABEL || 'Guide',
-          autogenerate: { directory: '/' },
+          autogenerate: { directory: '.' },
         },
       ],
     }),


### PR DESCRIPTION
## Summary
- Wire up the `remarkMermaid` remark plugin in `astro.config.mjs` so mermaid code blocks are transformed into renderable `<div class="mermaid-container">` elements at build time
- Fix sidebar `autogenerate` directory from `'/'` to `'.'` so Starlight resolves content pages relative to `src/content/docs/` instead of the filesystem root

Closes #42

## Test plan
- [ ] Docker build with ddos-guide content produces HTML with `.mermaid-container` elements
- [ ] Sidebar `<ul>` is populated with `<li>` entries for each content page
- [ ] Verify on live GitHub Pages site: mermaid diagrams render as SVGs, sidebar shows all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)