### PR TITLE
feat: dispatch downstream rebuild on new theme release

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -1,0 +1,21 @@
+name: Dispatch Downstream Rebuild
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Notify f5xc-docs-builder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch rebuild-image event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.REPO_ADMIN_TOKEN }}
+          repository: robinmordasiewicz/f5xc-docs-builder
+          event-type: rebuild-image
+          client-payload: '{"version": "${{ github.event.release.tag_name }}", "source_repo": "${{ github.repository }}"}'


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dispatch-downstream.yml` triggered by `release: published` events
- Sends `repository_dispatch` with `event-type: rebuild-image` to `robinmordasiewicz/f5xc-docs-builder`
- Passes release version and source repo in the client payload
- Uses existing `REPO_ADMIN_TOKEN` secret for cross-repo dispatch

Closes #44

## Test plan
- [ ] Verify workflow file syntax is valid
- [ ] After merge, push a releasable commit (`feat:` prefix) via PR to main
- [ ] Confirm `release.yml` runs and semantic-release creates a GitHub Release
- [ ] Confirm `dispatch-downstream.yml` triggers on the release event
- [ ] Confirm `f5xc-docs-builder` `build-image.yml` triggers via `repository_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)