### PR TITLE
feat: add package keywords for npm discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "withastro",
     "starlight-theme",
     "f5",
-    "documentation"
+    "f5xc",
+    "documentation",
+    "docs-theme"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Add `f5xc` and `docs-theme` keywords to `package.json` for better npm search visibility
- This `feat:` commit will trigger semantic-release to validate the dispatch-downstream workflow (#44)

Closes #46

## Test plan
- [ ] PR merges to main
- [ ] semantic-release creates a new version and GitHub Release
- [ ] `dispatch-downstream.yml` triggers on the release event
- [ ] `f5xc-docs-builder` receives the `rebuild-image` dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)