### PR TITLE
fix: use PAT for semantic-release and release on every commit type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Run semantic-release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,23 @@
 export default {
   branches: ['main'],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    ['@semantic-release/commit-analyzer', {
+      preset: 'angular',
+      releaseRules: [
+        { breaking: true, release: 'major' },
+        { type: 'feat', release: 'minor' },
+        { type: 'fix', release: 'patch' },
+        { type: 'perf', release: 'patch' },
+        { type: 'revert', release: 'patch' },
+        { type: 'docs', release: 'patch' },
+        { type: 'style', release: 'patch' },
+        { type: 'refactor', release: 'patch' },
+        { type: 'test', release: 'patch' },
+        { type: 'build', release: 'patch' },
+        { type: 'ci', release: 'patch' },
+        { type: 'chore', release: 'patch' },
+      ],
+    }],
     '@semantic-release/release-notes-generator',
     '@semantic-release/npm',
     '@semantic-release/github',


### PR DESCRIPTION
## Summary
- Switch `GITHUB_TOKEN` to `REPO_ADMIN_TOKEN` in `release.yml` so GitHub Releases created by semantic-release trigger the `release: published` event (GitHub blocks events from `GITHUB_TOKEN` to prevent recursion)
- Configure `release.config.js` commit-analyzer `releaseRules` to treat all commit types (`chore`, `docs`, `ci`, `style`, `refactor`, `test`, `build`) as patch releases — every merge to main creates a release

Closes #48

## Test plan
- [ ] Merge this PR to main
- [ ] Confirm semantic-release creates a new GitHub Release (patch bump)
- [ ] Confirm `dispatch-downstream.yml` triggers on the `release: published` event
- [ ] Confirm `f5xc-docs-builder` `build-image.yml` runs via `repository_dispatch`
- [ ] Confirm new Docker image is published to ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)