### PR TITLE
fix: gate dispatch-downstream on npm registry check

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -12,6 +12,13 @@ jobs:
     name: Notify f5xc-docs-builder
     runs-on: ubuntu-latest
     steps:
+      - name: Verify npm package version exists
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "Checking npm for @robinmordasiewicz/f5xc-docs-theme@${VERSION}..."
+          npm view "@robinmordasiewicz/f5xc-docs-theme@${VERSION}" version
+
       - name: Dispatch rebuild-image event
         uses: peter-evans/repository-dispatch@v3
         with:


### PR DESCRIPTION
Closes #52

## Summary
Gate the dispatch-downstream workflow on npm registry checks to prevent manual GitHub releases from triggering downstream rebuilds when the npm package hasn't been published.

## Test Plan
- [x] Verify workflow syntax is valid
- [x] Confirm npm registry check step will fail if package not found
- [x] Verify dispatch only occurs when package exists on npm