### PR TITLE
chore: add retry loop to npm registry check for CDN propagation

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -17,7 +17,16 @@ jobs:
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
           echo "Checking npm for @robinmordasiewicz/f5xc-docs-theme@${VERSION}..."
-          npm view "@robinmordasiewicz/f5xc-docs-theme@${VERSION}" version
+          for i in 1 2 3 4 5; do
+            if npm view "@robinmordasiewicz/f5xc-docs-theme@${VERSION}" version 2>/dev/null; then
+              echo "Version ${VERSION} confirmed on npm"
+              exit 0
+            fi
+            echo "Attempt ${i}: not found yet, waiting 15s for npm propagation..."
+            sleep 15
+          done
+          echo "::error::Version ${VERSION} not found on npm after 5 attempts"
+          exit 1
 
       - name: Dispatch rebuild-image event
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
## Summary

Add retry mechanism to handle CDN propagation delays when verifying npm package availability in the dispatch-downstream.yml workflow.

## Changes

- Implements 5 retry attempts with 15-second intervals
- Exits immediately on successful version verification
- Provides clear error messaging on failure
- Total timeout: up to 75 seconds

## Why

The npm registry doesn't instantly propagate packages to all CDN edge nodes. This retry loop allows the workflow to wait for availability without manual intervention.

Closes #54