### PR TITLE
ci: add paths-ignore to release workflow for non-package files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ name: Release
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
+      - '.editorconfig'
+      - '.gitignore'
+      - 'CLAUDE.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
+      - 'LICENSE'
+      - 'release.config.js'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/release.config.js
+++ b/release.config.js
@@ -9,7 +9,6 @@ export default {
         { type: 'fix', release: 'patch' },
         { type: 'perf', release: 'patch' },
         { type: 'revert', release: 'patch' },
-        { type: 'docs', release: 'patch' },
         { type: 'style', release: 'patch' },
         { type: 'refactor', release: 'patch' },
         { type: 'test', release: 'patch' },


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to `release.yml` mirroring `.npmignore` entries so docs-only changes don't trigger unnecessary npm publish + downstream Docker rebuild
- Remove `docs` type from `releaseRules` in `release.config.js` (defense in depth)
- Add `workflow_dispatch` trigger as manual override safety valve

Closes #56

## Test plan
- [ ] Verify this PR's merge triggers `release.yml` (it changes `.github/workflows/`)
- [ ] After merge, a docs-only push should trigger only `github-pages-deploy.yml`
- [ ] Verify `workflow_dispatch` button appears on the Release workflow page

🤖 Generated with [Claude Code](https://claude.com/claude-code)