### PR TITLE
Fix 404 on guide page after docs restructuring

### DIFF
--- a/docs/guide/index.mdx
+++ b/docs/guide/index.mdx
@@ -1,0 +1,6 @@
+---
+title: Guide
+description: Developer reference for configuring and customizing the F5 XC Docs Theme.
+---
+
+Developer reference for configuring and customizing the F5 XC Docs Theme Starlight plugin.


### PR DESCRIPTION
## Summary
- Adds `docs/guide/index.mdx` so Starlight can serve the `/guide/` route
- The hero "Get Started" button on the homepage currently leads to a 404 because no index file exists for the `guide/` directory
- This is a minimal landing page — Starlight auto-generates the sidebar with links to all guide pages

Closes #60

## Test plan
- [ ] CI passes (github-pages-deploy.yml triggers, release.yml skipped per paths-ignore)
- [ ] Homepage loads at `/f5xc-docs-theme/`
- [ ] "Get Started" hero link navigates to `/f5xc-docs-theme/guide/` without 404
- [ ] Sidebar shows guide pages under the Guide group

🤖 Generated with [Claude Code](https://claude.com/claude-code)