### PR TITLE
Add auto-merge caller workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,13 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    uses: robinmordasiewicz/f5xc-template/.github/workflows/auto-merge.yml@main


### PR DESCRIPTION
## Summary
- Add caller workflow that enables auto-merge (squash) on non-draft PRs
- Triggers on `pull_request: [opened, reopened, ready_for_review]`
- Calls reusable workflow from `robinmordasiewicz/f5xc-template`

Closes #62

## Test plan
- [ ] Verify "Auto Merge" workflow runs in the Actions tab for this PR
- [ ] Verify future PRs show "auto-merge enabled (squash)" badge
- [ ] Verify PRs auto-merge once "Check linked issues" passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)