### PR TITLE
feat: add home page link to site header

### DIFF
--- a/components/SiteTitle.astro
+++ b/components/SiteTitle.astro
@@ -1,0 +1,41 @@
+---
+import Default from '@astrojs/starlight/components/SiteTitle.astro';
+
+const docsHome = process.env.DOCS_HOME || 'https://robinmordasiewicz.github.io/f5xc-docs/';
+---
+
+<div class="home-title-group">
+  <a href={docsHome} class="home-link" aria-label="Documentation home">
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+      <polyline points="9 22 9 12 15 12 15 22"/>
+    </svg>
+  </a>
+  <span class="home-separator" aria-hidden="true"></span>
+  <Default {...Astro.props}><slot /></Default>
+</div>
+
+<style>
+  .home-title-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .home-link {
+    display: inline-flex;
+    align-items: center;
+    color: var(--sl-color-text-accent);
+    transition: opacity 0.2s ease;
+  }
+
+  .home-link:hover {
+    opacity: 0.7;
+  }
+
+  .home-separator {
+    width: 1px;
+    height: 1.25rem;
+    background-color: var(--sl-color-gray-5);
+  }
+</style>

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ export default function f5xcDocsTheme(): StarlightPlugin {
   return {
     name: 'f5xc-docs-theme',
     hooks: {
-      setup({ config, updateConfig, logger }) {
+      'config:setup'({ config, updateConfig, logger }) {
         updateConfig({
           customCss: [
             ...config.customCss,
@@ -14,6 +14,7 @@ export default function f5xcDocsTheme(): StarlightPlugin {
           components: {
             ...config.components,
             Footer: 'f5xc-docs-theme/components/Footer.astro',
+            SiteTitle: 'f5xc-docs-theme/components/SiteTitle.astro',
           },
         });
         logger.info('F5 XC docs theme loaded');

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "./fonts/font-face.css": "./fonts/font-face.css",
     "./styles/custom.css": "./styles/custom.css",
     "./components/Footer.astro": "./components/Footer.astro",
+    "./components/SiteTitle.astro": "./components/SiteTitle.astro",
     "./assets/f5-logo.svg": "./assets/f5-logo.svg"
   },
   "files": [


### PR DESCRIPTION
## Summary

- Override Starlight's `SiteTitle` component to prepend a home icon linking to the F5 XC documentation hub
- Home URL configurable via `DOCS_HOME` env var (default: `https://robinmordasiewicz.github.io/f5xc-docs/`)
- Migrate plugin hook from deprecated `setup` to `config:setup`

## Changes

| File | Change |
|------|--------|
| `components/SiteTitle.astro` | New component wrapping default SiteTitle with home icon + separator |
| `index.ts` | Register SiteTitle override, migrate to `config:setup` hook |
| `package.json` | Add `./components/SiteTitle.astro` export |

## Visual Result

```
[🏠 Home icon] | [F5 Logo] [Site Title]          [Search]          [GitHub] [Theme]
```

## Test plan

- [ ] Run `npx astro dev` and confirm the home icon appears in the header before the F5 logo
- [ ] Confirm clicking the home icon navigates to `https://robinmordasiewicz.github.io/f5xc-docs/`
- [ ] Confirm the F5 logo + site title still links to the current site root
- [ ] Set `DOCS_HOME=https://example.com` and confirm the home icon uses the custom URL
- [ ] After npm publish, verify a downstream rebuild shows the home link

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)