### PR TITLE
fix: use REPO_ADMIN_TOKEN in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,10 +4,15 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   auto-merge:
-    uses: robinmordasiewicz/f5xc-template/.github/workflows/auto-merge.yml@main
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: "!github.event.pull_request.draft"
+    steps:
+      - name: Enable auto-merge (squash)
+        continue-on-error: true
+        run: gh pr merge "$PR_URL" --auto --squash
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}


### PR DESCRIPTION
## Summary

- Inline the auto-merge step instead of calling the reusable template workflow
- Use `REPO_ADMIN_TOKEN` instead of `GITHUB_TOKEN` for `gh pr merge`
- This ensures the merge push to `main` triggers downstream workflows (Release, Pages Deploy)

## Problem

The auto-merge workflow was calling a reusable workflow from `f5xc-template` that hardcodes `GITHUB_TOKEN`. GitHub's anti-recursion protection prevents `GITHUB_TOKEN` pushes from triggering other workflows, so the Release workflow never ran after auto-merged PRs.

This is the same class of issue fixed in #49 for semantic-release.

## Test plan

- [ ] Merge this PR and verify the Release workflow triggers automatically
- [ ] Confirm a new npm version is published without manual `workflow_dispatch`

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)