### PR TITLE
feat: add Edit on GitHub link to page headers

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,6 +17,11 @@ export default defineConfig({
       logo: {
         src: 'f5xc-docs-theme/assets/f5-logo.svg',
       },
+      ...(process.env.GITHUB_REPOSITORY ? {
+        editLink: {
+          baseUrl: `https://github.com/${process.env.GITHUB_REPOSITORY}/edit/main/`,
+        },
+      } : {}),
       social: [
         {
           label: 'GitHub',

--- a/components/PageTitle.astro
+++ b/components/PageTitle.astro
@@ -2,7 +2,7 @@
 import Default from '@astrojs/starlight/components/PageTitle.astro';
 
 const docsHome = process.env.DOCS_HOME || 'https://robinmordasiewicz.github.io/f5xc-docs/';
-const { sidebar, entry, siteTitle } = Astro.locals.starlightRoute;
+const { sidebar, entry, siteTitle, editUrl } = Astro.locals.starlightRoute;
 
 function findTrail(entries: typeof sidebar, trail: { label: string }[] = []): { label: string }[] | null {
   for (const item of entries) {
@@ -29,5 +29,16 @@ const trail = findTrail(sidebar) || [];
     ))}
     <li aria-current="page"><span>{entry.data.title}</span></li>
   </ol>
+  {editUrl && (
+    <a href={editUrl.href} target="_blank" rel="noopener noreferrer" class="edit-link">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+        fill="none" stroke="currentColor" stroke-width="2"
+        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+        <path d="m15 5 4 4" />
+      </svg>
+      <span>Edit</span>
+    </a>
+  )}
 </nav>
 <Default {...Astro.props}><slot /></Default>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -225,6 +225,10 @@ h4, h5, h6 {
   padding-block: 0.5rem;
   margin-inline: -1rem;
   padding-inline: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
 .breadcrumbs ol {
@@ -254,6 +258,35 @@ h4, h5, h6 {
 
 .breadcrumbs [aria-current="page"] {
   color: var(--sl-color-white);
+}
+
+/* Edit on GitHub pill */
+.edit-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--sl-color-gray-3);
+  background: var(--sl-color-gray-6);
+  border: 1px solid var(--sl-color-gray-5);
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.edit-link:hover {
+  color: var(--sl-color-white);
+  background: var(--sl-color-gray-5);
+  border-color: var(--sl-color-gray-4);
+  text-decoration: none;
+}
+
+.edit-link svg {
+  flex-shrink: 0;
 }
 
 /* ===== Color Swatch Styles ===== */


### PR DESCRIPTION
Closes #98

## Summary
Add 'Edit on GitHub' link button to page navigation breadcrumbs, enabling users to quickly access the GitHub edit interface for the current page.

## Changes
- Configure Starlight editLink using GITHUB_REPOSITORY environment variable in astro.config.mjs
- Add editUrl to PageTitle component and display edit link with pencil icon
- Style edit link as rounded pill button with hover effects and smooth transitions

## Test Plan
- [ ] Verify edit link appears in page headers when GITHUB_REPOSITORY env var is set
- [ ] Test edit link points to correct GitHub edit URL for each page
- [ ] Verify styling matches F5 design system (gray pill with hover effects)
- [ ] Check responsive behavior on mobile devices
- [ ] Confirm accessibility (icon has aria-hidden, link is keyboard navigable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)