### PR TITLE
fix: correct Edit on GitHub link to use docs/ path

### DIFF
--- a/components/PageTitle.astro
+++ b/components/PageTitle.astro
@@ -18,6 +18,9 @@ function findTrail(entries: typeof sidebar, trail: { label: string }[] = []): { 
 }
 
 const trail = findTrail(sidebar) || [];
+const fixedEditUrl = editUrl
+  ? editUrl.href.replace('/src/content/docs/', '/docs/')
+  : undefined;
 ---
 
 <nav class="breadcrumbs" aria-label="Breadcrumb">
@@ -29,8 +32,8 @@ const trail = findTrail(sidebar) || [];
     ))}
     <li aria-current="page"><span>{entry.data.title}</span></li>
   </ol>
-  {editUrl && (
-    <a href={editUrl.href} target="_blank" rel="noopener noreferrer" class="edit-link">
+  {fixedEditUrl && (
+    <a href={fixedEditUrl} target="_blank" rel="noopener noreferrer" class="edit-link">
       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
         fill="none" stroke="currentColor" stroke-width="2"
         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">


### PR DESCRIPTION
Closes #100

## Description
The Edit on GitHub link was using the container-internal `src/content/docs/` path instead of the correct public `docs/` path.

## Changes
- **components/PageTitle.astro**: Added path replacement logic to transform the internal path to the correct public path

## Impact
The Edit on GitHub links in page headers will now correctly point to the public GitHub documentation files instead of container-internal paths.

## Testing
The fix is straightforward path replacement logic that transforms:
- From: `/src/content/docs/...`
- To: `/docs/...`