### PR TITLE
fix: add retry with exponential backoff to semantic-release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,25 @@ jobs:
           @semantic-release/github
 
       - name: Run semantic-release
-        run: npx semantic-release
+        run: |
+          max_attempts=3
+          attempt=1
+          delay=10
+          while [ $attempt -le $max_attempts ]; do
+            echo "Attempt $attempt of $max_attempts"
+            if npx semantic-release; then
+              echo "semantic-release succeeded"
+              exit 0
+            fi
+            if [ $attempt -eq $max_attempts ]; then
+              echo "semantic-release failed after $max_attempts attempts"
+              exit 1
+            fi
+            echo "Retrying in ${delay}s..."
+            sleep $delay
+            delay=$((delay * 2))
+            attempt=$((attempt + 1))
+          done
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Add resilience to the release pipeline by implementing exponential backoff retry logic for the semantic-release step.

## Changes
- 3 total retry attempts for semantic-release execution
- Initial delay: 10 seconds between retries
- Exponential backoff: doubles delay each attempt (10s → 20s → 40s)
- Succeeds immediately on first successful attempt
- Only fails after all retry attempts exhausted

## Why
The semantic-release step occasionally fails due to transient errors:
- npm registry timeouts
- GitHub API rate limits
- Temporary network issues

Without retry logic, these transient failures cause the entire release pipeline to abort, requiring manual investigation and re-triggering.

## Impact
✅ Improves release pipeline reliability
✅ Reduces false negatives from transient errors
✅ Maintains existing release behavior on success
✅ No changes to downstream workflows

Closes #108