### PR TITLE
feat: add starlight-llms-txt plugin to Astro config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from '@astrojs/starlight';
 import react from '@astrojs/react';
 import f5xcDocsTheme from 'f5xc-docs-theme';
 import remarkMermaid from './src/plugins/remark-mermaid.mjs';
+import starlightLlmsTxt from 'starlight-llms-txt';
 
 export default defineConfig({
   site: process.env.DOCS_SITE || 'https://robinmordasiewicz.github.io',
@@ -13,7 +14,13 @@ export default defineConfig({
   integrations: [
     starlight({
       title: process.env.DOCS_TITLE || 'Documentation',
-      plugins: [f5xcDocsTheme()],
+      plugins: [
+        f5xcDocsTheme(),
+        starlightLlmsTxt({
+          projectName: process.env.DOCS_TITLE || 'Documentation',
+          description: process.env.DOCS_DESCRIPTION || '',
+        }),
+      ],
       logo: {
         src: 'f5xc-docs-theme/assets/f5-logo.svg',
       },


### PR DESCRIPTION
Closes #112

## Summary
- Add `starlight-llms-txt` Starlight plugin import and registration in `astro.config.mjs`
- Plugin uses `DOCS_TITLE` and `DOCS_DESCRIPTION` env vars (set by builder's `entrypoint.sh`)
- Child Astro sites will auto-generate `/llms.txt` and `/llms-full.txt` at build time

## Test plan
- [ ] Theme npm package publishes successfully
- [ ] Child site builds with the new plugin present in config
- [ ] `/llms.txt` and `/llms-full.txt` are generated in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)