### PR TITLE
fix: enable rawContent in starlight-llms-txt to avoid React renderer errors

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig({
         starlightLlmsTxt({
           projectName: process.env.DOCS_TITLE || 'Documentation',
           description: process.env.DOCS_DESCRIPTION || '',
+          rawContent: true,
         }),
       ],
       logo: {


### PR DESCRIPTION
Closes #114

## Summary
- Set `rawContent: true` in the `starlightLlmsTxt` plugin config
- Prevents `NoMatchingRenderer` errors when generating `llms-full.txt` on pages containing React `.tsx` components (e.g., `PlaceholderForm`)
- Raw Markdown content is preserved instead of attempting HTML rendering

## Test plan
- [ ] Child site builds succeed (no `NoMatchingRenderer` error)
- [ ] `llms-full.txt` is generated with raw Markdown content
- [ ] `llms.txt` index is generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)