### PR TITLE
feat: add starlight-scroll-to-top plugin with F5 brand styling

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from '@astrojs/starlight';
 import react from '@astrojs/react';
 import f5xcDocsTheme from 'f5xc-docs-theme';
 import remarkMermaid from './src/plugins/remark-mermaid.mjs';
+import starlightScrollToTop from 'starlight-scroll-to-top';
 import starlightLlmsTxt from 'starlight-llms-txt';
 
 export default defineConfig({
@@ -16,6 +17,15 @@ export default defineConfig({
       title: process.env.DOCS_TITLE || 'Documentation',
       plugins: [
         f5xcDocsTheme(),
+        starlightScrollToTop({
+          showTooltip: true,
+          tooltipText: 'Scroll to top',
+          smoothScroll: true,
+          threshold: 10,
+          showProgressRing: true,
+          progressRingColor: '#e4002b',
+          showOnHomepage: false,
+        }),
         starlightLlmsTxt({
           projectName: process.env.DOCS_TITLE || 'Documentation',
           description: process.env.DOCS_DESCRIPTION || '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@robinmordasiewicz/f5xc-docs-theme",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "starlight-scroll-to-top": "^0.4.0"
+      },
       "peerDependencies": {
         "@astrojs/starlight": ">=0.34.0"
       }
@@ -5436,6 +5439,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5626,6 +5630,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/starlight-scroll-to-top": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/starlight-scroll-to-top/-/starlight-scroll-to-top-0.4.0.tgz",
+      "integrity": "sha512-lxsW5Sv+oKCI8CYZQ6Ue957cExiHMozK73LmmbsvpBKWryW+AKU4OXmX/1bTQNx+mVLZcpm2qTwKa1KX5VdEaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.35"
       }
     },
     "node_modules/stream-replace-string": {

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
   },
   "peerDependencies": {
     "@astrojs/starlight": ">=0.34.0"
+  },
+  "dependencies": {
+    "starlight-scroll-to-top": "^0.4.0"
   }
 }


### PR DESCRIPTION
## Summary
Add the starlight-scroll-to-top plugin to the Starlight documentation theme with F5 brand styling (red progress ring color: #e4002b).

## Changes
- Install starlight-scroll-to-top ^0.4.0 package
- Configure plugin in astro.config.mjs with:
  - Tooltip enabled ('Scroll to top')
  - Smooth scrolling enabled  
  - Progress ring enabled with F5 red color (#e4002b)
  - Threshold: 10px
  - Not shown on homepage

## Test plan
- [x] Package installs without errors
- [x] Plugin imports successfully in astro.config.mjs
- [x] All CI checks pass
- [x] Documentation builds successfully

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)