### PR TITLE
feat: add starlight-heading-badges plugin for inline heading badges

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import f5xcDocsTheme from 'f5xc-docs-theme';
 import remarkMermaid from './src/plugins/remark-mermaid.mjs';
 import starlightScrollToTop from 'starlight-scroll-to-top';
 import starlightImageZoom from 'starlight-image-zoom';
+import starlightHeadingBadges from 'starlight-heading-badges';
 import starlightLlmsTxt from 'starlight-llms-txt';
 
 export default defineConfig({
@@ -28,6 +29,7 @@ export default defineConfig({
           showOnHomepage: false,
         }),
         starlightImageZoom(),
+        starlightHeadingBadges(),
         starlightLlmsTxt({
           projectName: process.env.DOCS_TITLE || 'Documentation',
           description: process.env.DOCS_DESCRIPTION || '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "starlight-heading-badges": "^0.6.1",
         "starlight-image-zoom": "^0.13.2",
         "starlight-scroll-to-top": "^0.4.0"
       },
@@ -5631,6 +5632,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/starlight-heading-badges": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/starlight-heading-badges/-/starlight-heading-badges-0.6.1.tgz",
+      "integrity": "sha512-k89LlfxWSI136QOaedf70cZ29oDfv5xb6C2TIipt0RTk6TltVvUwFKk2H7gd+bVAjpH18CmzlGhCa5moEtyeZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-remark": "^6.0.1",
+        "github-slugger": "^2.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.32.0"
       }
     },
     "node_modules/starlight-image-zoom": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@astrojs/starlight": ">=0.34.0"
   },
   "dependencies": {
+    "starlight-heading-badges": "^0.6.1",
     "starlight-image-zoom": "^0.13.2",
     "starlight-scroll-to-top": "^0.4.0"
   }


### PR DESCRIPTION
Closes #124

## Summary
Add starlight-heading-badges plugin to enable inline badge support in markdown headings. This allows documentation writers to add visual badges (deprecated, beta, experimental, etc.) directly in heading text.

## Changes
- Add starlight-heading-badges ^0.6.1 dependency
- Register plugin in astro.config.mjs after starlight-image-zoom
- No breaking changes; fully compatible with existing setup

## Test Plan
- Verify plugin loads without errors
- Check that existing documentation renders correctly
- Confirm badges can be added to headings via markdown syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)