### PR TITLE
feat: add starlight-videos plugin for video content support

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import remarkMermaid from './src/plugins/remark-mermaid.mjs';
 import starlightScrollToTop from 'starlight-scroll-to-top';
 import starlightImageZoom from 'starlight-image-zoom';
 import starlightHeadingBadges from 'starlight-heading-badges';
+import starlightVideosPlugin from 'starlight-videos';
 import starlightLlmsTxt from 'starlight-llms-txt';
 
 export default defineConfig({
@@ -30,6 +31,7 @@ export default defineConfig({
         }),
         starlightImageZoom(),
         starlightHeadingBadges(),
+        starlightVideosPlugin(),
         starlightLlmsTxt({
           projectName: process.env.DOCS_TITLE || 'Documentation',
           description: process.env.DOCS_DESCRIPTION || '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,20 @@
       "dependencies": {
         "starlight-heading-badges": "^0.6.1",
         "starlight-image-zoom": "^0.13.2",
-        "starlight-scroll-to-top": "^0.4.0"
+        "starlight-scroll-to-top": "^0.4.0",
+        "starlight-videos": "^0.3.1"
       },
       "peerDependencies": {
         "@astrojs/starlight": ">=0.34.0"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-youtube": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-youtube/-/astro-embed-youtube-0.5.10.tgz",
+      "integrity": "sha512-hVlx77KQLjKzElVQnrU5znQ5/E60keVSAPrhuWvQQHuqva5auJtt8YBpOThkwDMuEKXjQybEF1/3C07RZ8MAOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lite-youtube-embed": "^0.3.4"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -3533,6 +3543,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/iso8601-duration": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/iso8601-duration/-/iso8601-duration-2.1.3.tgz",
+      "integrity": "sha512-OwkROKDXYhqKTl9uyB+/+lQ/Tx+L9LVb9tNRcsO4LtCSBDrmYbzyJLg9rGjYKAPDabD6IVdjMyUnnULHpejrCg==",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3562,6 +3578,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/lite-youtube-embed": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.3.4.tgz",
+      "integrity": "sha512-aXgxpwK7AIW58GEbRzA8EYaY4LWvF3FKak6B9OtSJmuNyLhX2ouD4cMTxz/yR5HFInhknaYd2jLWOTRTvT8oAw==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -5634,6 +5656,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/srt-parser-2": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/srt-parser-2/-/srt-parser-2-1.2.3.tgz",
+      "integrity": "sha512-dANP1AyJTI503H0/kXwRza+7QxDB3BqeFvEKTF4MI9lQcBe8JbRUQTKVIGzGABJCwBovEYavZ2Qsdm/s8XKz8A==",
+      "license": "MIT",
+      "bin": {
+        "srt-parser-2": "bin/index.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/starlight-heading-badges": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/starlight-heading-badges/-/starlight-heading-badges-0.6.1.tgz",
@@ -5680,6 +5714,25 @@
       },
       "peerDependencies": {
         "@astrojs/starlight": ">=0.35"
+      }
+    },
+    "node_modules/starlight-videos": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/starlight-videos/-/starlight-videos-0.3.1.tgz",
+      "integrity": "sha512-CY9reWTXB/wfgMX3Td7EX37oV8NmceO6OpvCm7dyAqdXVKyapPf6YmpNfOYMJpu9I3EByqPm3dYxJC1wpAszpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astro-community/astro-embed-youtube": "^0.5.6",
+        "hastscript": "^9.0.0",
+        "iso8601-duration": "^2.1.2",
+        "srt-parser-2": "^1.2.3",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.34.0"
       }
     },
     "node_modules/stream-replace-string": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "starlight-heading-badges": "^0.6.1",
     "starlight-image-zoom": "^0.13.2",
-    "starlight-scroll-to-top": "^0.4.0"
+    "starlight-scroll-to-top": "^0.4.0",
+    "starlight-videos": "^0.3.1"
   }
 }


### PR DESCRIPTION
## Summary
Integrates the starlight-videos plugin to enable embedded video content in documentation pages.

## Changes
- Install starlight-videos dependency (^0.3.1)
- Import and configure starlightVideosPlugin in astro.config.mjs
- Updated package.json with new dependency

## Benefits
- Enables video content embedding in documentation
- Provides responsive video player integration
- Improves content delivery for video-based documentation

Closes #126