### PR TITLE
fix: remove PageTitle override that blocks starlight-page-actions plugin

### DIFF
--- a/components/PageTitle.astro
+++ b/components/PageTitle.astro
@@ -1,4 +1,0 @@
----
-import Default from '@astrojs/starlight/components/PageTitle.astro';
----
-<Default {...Astro.props}><slot /></Default>

--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,6 @@ export default function f5xcDocsTheme(): StarlightPlugin {
             Banner: 'f5xc-docs-theme/components/Banner.astro',
             Footer: 'f5xc-docs-theme/components/Footer.astro',
             SiteTitle: 'f5xc-docs-theme/components/SiteTitle.astro',
-            PageTitle: 'f5xc-docs-theme/components/PageTitle.astro',
           },
         });
         logger.info('F5 XC docs theme loaded');


### PR DESCRIPTION
Closes #132

## Problem
The custom PageTitle component override was preventing the starlight-page-actions plugin from injecting page action buttons into the page title area.

## Solution
Remove the no-op PageTitle component wrapper and its export from the theme configuration, allowing the plugin to use Starlight's default PageTitle component which supports plugin integration.

## Changes
- Delete  (no-op wrapper)
- Remove  export from 

## Testing
The starlight-page-actions plugin should now display page action buttons (copy, share, AI chat) in the page header as expected.