### PR TITLE
fix: remove stale PageTitle.astro export from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "./components/Banner.astro": "./components/Banner.astro",
     "./components/Footer.astro": "./components/Footer.astro",
     "./components/SiteTitle.astro": "./components/SiteTitle.astro",
-    "./components/PageTitle.astro": "./components/PageTitle.astro",
     "./assets/f5-logo.svg": "./assets/f5-logo.svg"
   },
   "files": [


### PR DESCRIPTION
## Summary
- Removes stale `./components/PageTitle.astro` export entry from `package.json`
- The component was deleted in PR #133 but the export map entry was left behind
- Prevents potential import errors for theme consumers

Closes #134

## Test plan
- [ ] Verify package.json is valid JSON
- [ ] Confirm no other references to PageTitle.astro exist
- [ ] Check that theme consumers can still import all valid exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)