### PR TITLE
feat: improve icon card styling with responsive dimensions

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -357,9 +357,9 @@ h4, h5, h6 {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1rem;
+  padding: 0.5rem;
   background: var(--sl-color-gray-7, #faf9f7);
-  height: 5rem;
+  aspect-ratio: 1;
 }
 
 :root:not([data-theme='light']) .icon-card-image {
@@ -367,8 +367,8 @@ h4, h5, h6 {
 }
 
 .icon-card-image img {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
 }
 


### PR DESCRIPTION
Closes #142

## Summary
Improved icon card styling with better responsive behavior and flexible sizing.

## Changes
- Reduce padding from 1rem to 0.5rem for better spacing
- Change fixed height (5rem) to aspect-ratio: 1 for flexible scaling
- Make image dimensions responsive (100% instead of fixed 2.5rem)

## Impact
More flexible, responsive icon card layout that adapts better to different container sizes and screen dimensions.