### PR TITLE
feat: integrate video and image zoom into markdown content

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,6 +21,8 @@ export default defineConfig({
     starlight({
       title: process.env.DOCS_TITLE || 'Documentation',
       plugins: [
+        starlightVideosPlugin(),
+        starlightImageZoom(),
         f5xcDocsTheme(),
         starlightScrollToTop({
           showTooltip: true,
@@ -31,9 +33,7 @@ export default defineConfig({
           progressRingColor: '#e4002b',
           showOnHomepage: false,
         }),
-        starlightImageZoom(),
         starlightHeadingBadges(),
-        starlightVideosPlugin(),
         starlightPageActions(),
         starlightIconsPlugin(),
         starlightLlmsTxt({

--- a/components/MarkdownContent.astro
+++ b/components/MarkdownContent.astro
@@ -1,0 +1,7 @@
+---
+import StarlightVideosMarkdownContent from 'starlight-videos/components/MarkdownContent.astro'
+import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
+---
+
+<ImageZoom />
+<StarlightVideosMarkdownContent><slot /></StarlightVideosMarkdownContent>

--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,7 @@ export default function f5xcDocsTheme(): StarlightPlugin {
             Banner: 'f5xc-docs-theme/components/Banner.astro',
             Footer: 'f5xc-docs-theme/components/Footer.astro',
             SiteTitle: 'f5xc-docs-theme/components/SiteTitle.astro',
+            MarkdownContent: 'f5xc-docs-theme/components/MarkdownContent.astro',
           },
         });
         logger.info('F5 XC docs theme loaded');

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "./components/Banner.astro": "./components/Banner.astro",
     "./components/Footer.astro": "./components/Footer.astro",
     "./components/SiteTitle.astro": "./components/SiteTitle.astro",
+    "./components/MarkdownContent.astro": "./components/MarkdownContent.astro",
     "./assets/f5-logo.svg": "./assets/f5-logo.svg",
     "./assets/github-avatar.png": "./assets/github-avatar.png"
   },


### PR DESCRIPTION
Closes #150

## Summary
Reorder Starlight plugins and add MarkdownContent component to properly integrate starlight-videos and starlight-image-zoom functionality.

## Changes
- Reordered plugins in astro.config.mjs to place videos and image zoom before theme initialization
- Added new MarkdownContent.astro component that composes both video and zoom functionality
- Exported new component in index.ts and package.json

## Impact
- Enables video and image zoom functionality in markdown content
- Improves plugin initialization order for proper feature support