### PR TITLE
feat: hide index pages from sidebar and breadcrumbs

### DIFF
--- a/components/Banner.astro
+++ b/components/Banner.astro
@@ -4,6 +4,9 @@ import Default from '@astrojs/starlight/components/Banner.astro';
 const docsHome = process.env.DOCS_HOME || 'https://robinmordasiewicz.github.io/f5xc-docs/';
 const { sidebar, entry, siteTitle, editUrl } = Astro.locals.starlightRoute;
 
+const isIndexPage = entry.filePath ? /(?:^|[\\/])index\.mdx?$/.test(entry.filePath) : false;
+const hideBreadcrumbs = isIndexPage && entry.data.sidebar?.hidden !== false;
+
 function findTrail(entries: typeof sidebar, trail: { label: string }[] = []): { label: string }[] | null {
   for (const item of entries) {
     if (item.type === 'link' && item.isCurrent) {
@@ -24,24 +27,26 @@ const fixedEditUrl = editUrl
 ---
 
 <Default {...Astro.props}><slot /></Default>
-<nav class="breadcrumbs" aria-label="Breadcrumb">
-  <ol>
-    <li><a href={docsHome}>Home</a></li>
-    <li><a href={import.meta.env.BASE_URL}>{siteTitle}</a></li>
-    {trail.map((crumb) => (
-      <li><span>{crumb.label}</span></li>
-    ))}
-    <li aria-current="page"><span>{entry.data.title}</span></li>
-  </ol>
-  {fixedEditUrl && (
-    <a href={fixedEditUrl} target="_blank" rel="noopener noreferrer" class="edit-link">
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
-        fill="none" stroke="currentColor" stroke-width="2"
-        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
-        <path d="m15 5 4 4" />
-      </svg>
-      <span>Edit</span>
-    </a>
-  )}
-</nav>
+{!hideBreadcrumbs && (
+  <nav class="breadcrumbs" aria-label="Breadcrumb">
+    <ol>
+      <li><a href={docsHome}>Home</a></li>
+      <li><a href={import.meta.env.BASE_URL}>{siteTitle}</a></li>
+      {trail.map((crumb) => (
+        <li><span>{crumb.label}</span></li>
+      ))}
+      <li aria-current="page"><span>{entry.data.title}</span></li>
+    </ol>
+    {fixedEditUrl && (
+      <a href={fixedEditUrl} target="_blank" rel="noopener noreferrer" class="edit-link">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" stroke-width="2"
+          stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+          <path d="m15 5 4 4" />
+        </svg>
+        <span>Edit</span>
+      </a>
+    )}
+  </nav>
+)}

--- a/index.ts
+++ b/index.ts
@@ -4,10 +4,14 @@ export default function f5xcDocsTheme(): StarlightPlugin {
   return {
     name: 'f5xc-docs-theme',
     hooks: {
-      'config:setup'({ config, updateConfig, logger }) {
+      'config:setup'({ config, updateConfig, addRouteMiddleware, logger }) {
+        addRouteMiddleware({
+          entrypoint: 'f5xc-docs-theme/route-middleware',
+          order: 'pre',
+        });
         updateConfig({
           customCss: [
-            ...config.customCss,
+            ...(config.customCss ?? []),
             'f5xc-docs-theme/fonts/font-face.css',
             'f5xc-docs-theme/styles/custom.css',
           ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/f5xc-docs-theme",
+  "name": "f5xc-docs-theme",
   "version": "0.1.0",
   "description": "F5 Distributed Cloud branded Starlight documentation theme",
   "type": "module",
@@ -21,10 +21,12 @@
     "./components/SiteTitle.astro": "./components/SiteTitle.astro",
     "./components/MarkdownContent.astro": "./components/MarkdownContent.astro",
     "./assets/f5-logo.svg": "./assets/f5-logo.svg",
-    "./assets/github-avatar.png": "./assets/github-avatar.png"
+    "./assets/github-avatar.png": "./assets/github-avatar.png",
+    "./route-middleware": "./route-middleware.ts"
   },
   "files": [
     "index.ts",
+    "route-middleware.ts",
     "astro.config.mjs",
     "fonts/",
     "styles/",

--- a/route-middleware.ts
+++ b/route-middleware.ts
@@ -1,0 +1,76 @@
+import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
+import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+
+type SidebarEntry = StarlightRouteData['sidebar'][number];
+
+function isIndexPage(filePath: string | undefined): boolean {
+  if (!filePath) return false;
+  return /(?:^|[\\/])index\.mdx?$/.test(filePath);
+}
+
+function filterIndexPages(
+  entries: SidebarEntry[],
+  indexHrefs: Set<string>
+): SidebarEntry[] {
+  return entries.reduce<SidebarEntry[]>((acc, entry) => {
+    if (entry.type === 'link') {
+      if (!indexHrefs.has(entry.href)) {
+        acc.push(entry);
+      }
+    } else {
+      acc.push({
+        ...entry,
+        entries: filterIndexPages(entry.entries, indexHrefs),
+      });
+    }
+    return acc;
+  }, []);
+}
+
+export const onRequest = defineRouteMiddleware(async (context, next) => {
+  const route = context.locals.starlightRoute;
+  const entry = route.entry;
+
+  const currentIsIndex = isIndexPage(entry.filePath);
+
+  if (currentIsIndex) {
+    const sidebarExplicitlyShown = entry.data.sidebar?.hidden === false;
+
+    if (!sidebarExplicitlyShown) {
+      // Hide TOC on index pages unless explicitly configured
+      if (!entry.data.tableOfContents) {
+        route.toc = undefined;
+      }
+    }
+  }
+
+  // Build set of index page hrefs that should be hidden from sidebar.
+  // We check every sidebar link to see if its href matches an index page pattern.
+  // Index pages in the sidebar have hrefs ending with '/' for directory index pages.
+  // We filter them out unless the current page's own index has sidebar.hidden explicitly set to false.
+  const { getCollection } = await import('astro:content');
+  const docs = await getCollection('docs');
+
+  const indexHrefs = new Set<string>();
+  for (const doc of docs) {
+    const docFilePath = (doc as { filePath?: string }).filePath ?? doc.id;
+    if (isIndexPage(docFilePath)) {
+      const sidebarData = (doc.data as { sidebar?: { hidden?: boolean } }).sidebar;
+      // Only hide if not explicitly shown
+      if (sidebarData?.hidden !== false) {
+        // Compute the href for this index page
+        const slug = doc.id.replace(/(?:^|[\\/])index$/, '').replace(/\/index$/, '');
+        const normalizedSlug = slug === 'index' ? '' : slug;
+        const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+        const href = normalizedSlug ? `${base}/${normalizedSlug}/` : `${base}/`;
+        indexHrefs.add(href);
+      }
+    }
+  }
+
+  if (indexHrefs.size > 0) {
+    route.sidebar = filterIndexPages(route.sidebar, indexHrefs);
+  }
+
+  await next();
+});


### PR DESCRIPTION
Closes #152

Add route middleware to filter index pages from sidebar navigation and breadcrumbs based on sidebar.hidden configuration. Index pages are hidden by default unless explicitly configured to display.