### PR TITLE
fix: update npm package name in dispatch-downstream workflow

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -16,9 +16,9 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
-          echo "Checking npm for @robinmordasiewicz/f5xc-docs-theme@${VERSION}..."
+          echo "Checking npm for f5xc-docs-theme@${VERSION}..."
           for i in 1 2 3 4 5; do
-            if npm view "@robinmordasiewicz/f5xc-docs-theme@${VERSION}" version 2>/dev/null; then
+            if npm view "f5xc-docs-theme@${VERSION}" version 2>/dev/null; then
               echo "Version ${VERSION} confirmed on npm"
               exit 0
             fi


### PR DESCRIPTION
## Summary
- Updates dispatch-downstream.yml to check `f5xc-docs-theme` (non-scoped) instead of `@robinmordasiewicz/f5xc-docs-theme`
- The scoped package stopped at v1.22.0; all new releases publish to the non-scoped name

## Test plan
- [ ] Verify next release triggers dispatch-downstream successfully
- [ ] Verify f5xc-docs-builder receives the rebuild-image event

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)