### PR TITLE
fix: remove duplicate edit link from footer

### DIFF
--- a/components/EditLink.astro
+++ b/components/EditLink.astro
@@ -1,0 +1,3 @@
+---
+// Intentionally empty — edit link is provided by Banner.astro in the breadcrumb bar
+---

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ export default function f5xcDocsTheme(): StarlightPlugin {
           components: {
             ...config.components,
             Banner: 'f5xc-docs-theme/components/Banner.astro',
+            EditLink: 'f5xc-docs-theme/components/EditLink.astro',
             Footer: 'f5xc-docs-theme/components/Footer.astro',
             SiteTitle: 'f5xc-docs-theme/components/SiteTitle.astro',
             MarkdownContent: 'f5xc-docs-theme/components/MarkdownContent.astro',


### PR DESCRIPTION
Closes #166

## Summary
Override Starlight's default EditLink component with an intentionally empty component. The edit link functionality is already provided by Banner.astro in the breadcrumb navigation above the main content.

## Why
- Eliminates redundant edit link in the footer
- Reduces visual clutter
- Improves UX by providing a single, prominent edit link in the breadcrumb area

## Changes
- Created empty  with explanatory comment
- Registered override in  plugin configuration

## Testing
- Component renders correctly as empty
- Edit link in Banner.astro breadcrumb still functions as expected
- Footer no longer displays duplicate edit link