### PR TITLE
fix: add EditLink.astro to package.json exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "./fonts/font-face.css": "./fonts/font-face.css",
     "./styles/custom.css": "./styles/custom.css",
     "./components/Banner.astro": "./components/Banner.astro",
+    "./components/EditLink.astro": "./components/EditLink.astro",
     "./components/Footer.astro": "./components/Footer.astro",
     "./components/SiteTitle.astro": "./components/SiteTitle.astro",
     "./components/MarkdownContent.astro": "./components/MarkdownContent.astro",


### PR DESCRIPTION
## Problem
Downstream f5xc-docs-builder build fails with:
```
Missing "./components/EditLink.astro" specifier in "f5xc-docs-theme" package
```

## Solution
Add EditLink.astro export to the package.json exports map.

Closes #170