### PR TITLE
feat: add starlight-mega-menu plugin for top navigation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import starlightVideosPlugin from 'starlight-videos';
 import starlightPageActions from 'starlight-page-actions';
 import { starlightIconsPlugin } from 'starlight-plugin-icons';
 import starlightLlmsTxt from 'starlight-llms-txt';
+import starlightMegaMenu from 'starlight-mega-menu';
 
 export default defineConfig({
   site: process.env.DOCS_SITE || 'https://robinmordasiewicz.github.io',
@@ -21,6 +22,90 @@ export default defineConfig({
     starlight({
       title: process.env.DOCS_TITLE || 'Documentation',
       plugins: [
+        starlightMegaMenu({
+          items: [
+            {
+              label: 'Products',
+              content: {
+                layout: 'grid',
+                columns: 2,
+                categories: [
+                  {
+                    title: 'App Security',
+                    items: [
+                      {
+                        label: 'Web App & API Protection',
+                        description: 'Comprehensive app and API security',
+                        href: '/products/waap/',
+                      },
+                      {
+                        label: 'Bot Defense',
+                        description: 'AI-driven bot mitigation',
+                        href: '/products/bot-defense/',
+                      },
+                    ],
+                  },
+                  {
+                    title: 'Networking',
+                    items: [
+                      {
+                        label: 'Multi-Cloud Networking',
+                        description: 'Connect apps across clouds',
+                        href: '/products/mcn/',
+                      },
+                      {
+                        label: 'DNS & DNS Load Balancing',
+                        description: 'Intelligent DNS services',
+                        href: '/products/dns/',
+                      },
+                    ],
+                  },
+                ],
+                footer: {
+                  label: 'View all products',
+                  href: '/products/',
+                  description: 'Explore the full F5 Distributed Cloud suite',
+                },
+              },
+            },
+            {
+              label: 'Solutions',
+              content: {
+                layout: 'list',
+                categories: [
+                  {
+                    title: 'By Use Case',
+                    items: [
+                      {
+                        label: 'API Security',
+                        description: 'Protect APIs across multi-cloud environments',
+                        href: '/solutions/api-security/',
+                      },
+                      {
+                        label: 'Multi-Cloud Networking',
+                        description: 'Secure connectivity across any cloud',
+                        href: '/solutions/multi-cloud/',
+                      },
+                      {
+                        label: 'Edge Computing',
+                        description: 'Deploy apps at the edge with F5 XC AppStack',
+                        href: '/solutions/edge/',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              label: 'Docs',
+              href: '/',
+            },
+            {
+              label: 'Support',
+              href: 'https://my.f5.com/manage/s/',
+            },
+          ],
+        }),
         starlightVideosPlugin(),
         starlightImageZoom(),
         f5xcDocsTheme(),

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "starlight-heading-badges": "^0.6.1",
     "starlight-image-zoom": "^0.13.2",
+    "starlight-mega-menu": "^1.0.1",
     "starlight-page-actions": "^0.5.0",
     "starlight-plugin-icons": "^1.1.3",
     "starlight-scroll-to-top": "^0.4.0",


### PR DESCRIPTION
## Summary
- Adds `starlight-mega-menu@^1.0.1` as a dependency for HashiCorp-style dropdown navigation
- Configures mega-menu in `astro.config.mjs` with F5 Distributed Cloud product navigation (Products, Solutions, Docs, Support)
- All F5XC docs sites automatically get the unified mega-menu header

Closes #178

## Test plan
- [ ] Verify `npm install` resolves `starlight-mega-menu` and its Radix UI dependency
- [ ] Verify `astro build` passes with the mega-menu plugin configured
- [ ] Verify desktop mega-menu renders with Products/Solutions dropdowns
- [ ] Verify mobile hamburger menu works at narrow viewports
- [ ] Verify dark/light theme toggle applies to mega-menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)