### PR TITLE
fix: reduce scroll-to-top button size

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -385,4 +385,21 @@ h4, h5, h6 {
   word-break: break-word;
 }
 
-/* release pipeline verified */
+/* ===== Scroll-to-Top Button Size Override ===== */
+.scroll-to-top-button {
+  width: 36px !important;
+  height: 36px !important;
+}
+.scroll-to-top-button svg {
+  width: 20px !important;
+  height: 20px !important;
+}
+.scroll-to-top-button .scroll-progress-ring {
+  width: 36px !important;
+  height: 36px !important;
+}
+.scroll-to-top-button .scroll-progress-ring circle {
+  cx: 18;
+  cy: 18;
+  r: 16;
+}


### PR DESCRIPTION
## Summary
- Reduces scroll-to-top button from 47px to 36px
- Reduces arrow icon SVG from 35px to 20px
- Scales progress ring to match new button size

Closes #184

## Test plan
- [ ] Verify button appears smaller on content pages after scrolling
- [ ] Verify progress ring still renders correctly
- [ ] Verify tooltip still appears on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)