### PR TITLE
feat: Add theme test suite and content config for Starlight 0.37.6

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,7 @@
+import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+};

--- a/src/content/docs/tests/asides.mdx
+++ b/src/content/docs/tests/asides.mdx
@@ -1,0 +1,71 @@
+---
+title: Asides
+description: Test page for all aside variants and rich content inside asides.
+sidebar:
+  order: 101
+  label: Asides
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Markdown Fence Syntax
+
+Each aside type uses the `:::` fence syntax with its default title.
+
+:::note
+This is a **note** aside. It draws attention to supplementary information the reader should be aware of.
+:::
+
+:::tip
+This is a **tip** aside. It highlights a best practice or useful shortcut.
+:::
+
+:::caution
+This is a **caution** aside. It warns about a potential pitfall or non-obvious behavior.
+:::
+
+:::danger
+This is a **danger** aside. It flags a destructive or irreversible action.
+:::
+
+## Component Syntax with Custom Titles
+
+<Aside type="note" title="Custom Note Title">
+This aside uses the `<Aside>` component with a custom title override.
+</Aside>
+
+<Aside type="tip" title="Pro Tip">
+You can nest **bold**, *italic*, and `inline code` inside aside components.
+</Aside>
+
+<Aside type="caution" title="Watch Out">
+Be careful when upgrading dependencies — check the changelog first.
+</Aside>
+
+<Aside type="danger" title="Destructive Action">
+Running `git reset --hard` will permanently discard uncommitted changes.
+</Aside>
+
+## Rich Content Inside Asides
+
+:::tip[Aside with mixed content]
+Here is a code block inside an aside:
+
+```bash
+npm install @astrojs/starlight
+```
+
+A list of items:
+
+- First item with **bold text**
+- Second item with `inline code`
+- Third item with a [link to Starlight docs](https://starlight.astro.build)
+:::
+
+## Theme Checks
+
+- Border-left color differs per variant (blue, purple, yellow, red)
+- Background tint is visible in both light and dark modes
+- Text contrast remains readable in both themes
+- Box-shadow is subtle but visible around each aside
+- Rounded corners (0.75rem) on all asides

--- a/src/content/docs/tests/badges.mdx
+++ b/src/content/docs/tests/badges.mdx
@@ -1,0 +1,66 @@
+---
+title: Badges
+description: Test page for Badge variants, sizes, and heading badges plugin.
+sidebar:
+  order: 104
+  label: Badges
+  badge:
+    text: New
+    variant: tip
+---
+
+import { Badge } from '@astrojs/starlight/components';
+
+## Inline Badge Variants
+
+All six badge variants rendered inline:
+
+<Badge text="Default" /> <Badge text="Note" variant="note" /> <Badge text="Danger" variant="danger" /> <Badge text="Success" variant="success" /> <Badge text="Tip" variant="tip" /> <Badge text="Caution" variant="caution" />
+
+## Badge Sizes
+
+<Badge text="Small" size="small" /> <Badge text="Medium" size="medium" /> <Badge text="Large" size="large" />
+
+Each size with a variant:
+
+<Badge text="Small Tip" variant="tip" size="small" /> <Badge text="Medium Danger" variant="danger" size="medium" /> <Badge text="Large Success" variant="success" size="large" />
+
+## Heading Badges
+
+The following headings use the `starlight-heading-badges` plugin syntax.
+
+### Feature Complete :badge[Stable]{variant=success}
+
+This heading has a success badge indicating the feature is stable.
+
+### Experimental API :badge[Beta]{variant=caution}
+
+This heading has a caution badge indicating the API is experimental.
+
+### Legacy System :badge[Deprecated]{variant=danger}
+
+This heading has a danger badge indicating deprecation.
+
+### New Feature :badge[New]{variant=tip}
+
+This heading has a tip badge indicating a new feature.
+
+### Documentation :badge[Updated]{variant=note}
+
+This heading has a note badge indicating recent updates.
+
+### Default Badge :badge[Info]
+
+This heading has a default badge with no variant specified.
+
+## Sidebar Badge
+
+Check the sidebar: this page has a "New" badge with the `tip` variant applied via frontmatter.
+
+## Theme Checks
+
+- Badge background colors per variant differ between dark and light modes
+- Dark mode uses deep tones (red-4, jade-4, tangerine-4, eggplant-4, bay-4)
+- Light mode uses light tones (red-1, jade-1, tangerine-1, eggplant-1, bay-1)
+- Heading badges align inline with heading text
+- Sidebar badge renders next to the page label

--- a/src/content/docs/tests/cards.mdx
+++ b/src/content/docs/tests/cards.mdx
@@ -1,0 +1,72 @@
+---
+title: Cards
+description: Test page for Card, CardGrid, stagger layout, and LinkCard components.
+sidebar:
+  order: 103
+  label: Cards
+---
+
+import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+## Single Card
+
+<Card title="Single Card" icon="star">
+  This is a standalone card with an icon. Cards are useful for highlighting key information or features.
+</Card>
+
+## Card Grid
+
+<CardGrid>
+  <Card title="Performance" icon="rocket">
+    Astro delivers zero-JS by default for fast page loads.
+  </Card>
+  <Card title="Customizable" icon="pencil">
+    Starlight provides extensive theming and plugin options.
+  </Card>
+  <Card title="Accessible" icon="heart">
+    Built-in accessibility features ensure content reaches everyone.
+  </Card>
+  <Card title="Documented" icon="open-book">
+    Comprehensive documentation makes getting started straightforward.
+  </Card>
+</CardGrid>
+
+## Stagger Layout
+
+<CardGrid stagger>
+  <Card title="Step One" icon="setting">
+    Configure your project settings and environment variables.
+  </Card>
+  <Card title="Step Two" icon="document">
+    Create your content pages using MDX format.
+  </Card>
+  <Card title="Step Three" icon="laptop">
+    Preview locally with the development server.
+  </Card>
+  <Card title="Step Four" icon="rocket">
+    Deploy to your hosting platform of choice.
+  </Card>
+</CardGrid>
+
+## Link Cards
+
+<CardGrid>
+  <LinkCard
+    title="Starlight Documentation"
+    description="Learn how to build documentation sites with Starlight."
+    href="https://starlight.astro.build"
+  />
+  <LinkCard
+    title="Astro Documentation"
+    description="Explore the Astro framework for content-driven websites."
+    href="https://docs.astro.build"
+  />
+</CardGrid>
+
+## Theme Checks
+
+- Card border color adapts between light and dark modes
+- Hover background effect is visible on cards
+- LinkCard arrow icon color matches the accent color
+- Stagger layout offsets alternate cards vertically
+- Icons render correctly inside card headers

--- a/src/content/docs/tests/code-blocks.mdx
+++ b/src/content/docs/tests/code-blocks.mdx
@@ -1,0 +1,166 @@
+---
+title: Code Blocks
+description: Test page for syntax highlighting, terminal mode, line highlights, and diff blocks.
+sidebar:
+  order: 105
+  label: Code Blocks
+---
+
+## Language Blocks
+
+### JavaScript
+
+```js
+function fibonacci(n) {
+  if (n <= 1) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+console.log(fibonacci(10)); // 55
+```
+
+### Python
+
+```python
+def fibonacci(n: int) -> int:
+    if n <= 1:
+        return n
+    return fibonacci(n - 1) + fibonacci(n - 2)
+
+print(fibonacci(10))  # 55
+```
+
+### Bash
+
+```bash
+#!/bin/bash
+for i in $(seq 1 5); do
+  echo "Iteration $i"
+done
+```
+
+### YAML
+
+```yaml
+site:
+  title: Documentation
+  base: /
+  integrations:
+    - starlight
+    - react
+```
+
+### JSON
+
+```json
+{
+  "name": "f5xc-docs-theme",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}
+```
+
+### HTML
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Test Page</title>
+  </head>
+  <body>
+    <h1>Hello World</h1>
+  </body>
+</html>
+```
+
+### CSS
+
+```css
+:root {
+  --sl-color-accent: #f06680;
+  --sl-font: "proximaNova", system-ui;
+}
+
+h1 {
+  font-family: var(--sl-font-heading);
+  font-weight: 700;
+}
+```
+
+### TypeScript
+
+```ts
+interface Config {
+  title: string;
+  base: string;
+  plugins: string[];
+}
+
+const config: Config = {
+  title: "Documentation",
+  base: "/",
+  plugins: ["starlight", "react"],
+};
+```
+
+## Terminal Mode
+
+```bash title="Terminal"
+npm install f5xc-docs-theme
+npx astro build
+npx astro preview
+```
+
+## File Name Title
+
+```ts title="src/config.ts"
+export default {
+  site: "https://example.com",
+  title: "My Docs",
+};
+```
+
+## Line Highlighting
+
+```js {1,3-5}
+const name = "highlighted"; // line 1 highlighted
+const other = "normal";
+const a = 1; // lines 3-5 highlighted
+const b = 2;
+const c = 3;
+const d = "normal again";
+```
+
+## Inserted and Deleted Lines
+
+```js ins={2} del={3}
+const config = {
+  theme: "dark", // inserted
+  theme: "light", // deleted
+  lang: "en",
+};
+```
+
+## Diff Block
+
+```diff
+- const oldValue = "deprecated";
++ const newValue = "replacement";
+  const unchanged = "stays";
+- removeThis();
++ addThis();
+```
+
+## Theme Checks
+
+- Code block background color adapts to theme
+- Terminal header background is `#323232` with macOS traffic light dots
+- Terminal border uses `rgba(255, 255, 255, 0.15)` in dark, `rgba(0, 0, 0, 0.2)` in light
+- Dark mode terminal body uses `#1a1b26`
+- Syntax colors remain readable in both themes
+- Line highlights have visible background tint
+- Inserted lines show green tint, deleted lines show red tint
+- Code blocks have 0.75rem border radius and box shadow

--- a/src/content/docs/tests/custom-css.mdx
+++ b/src/content/docs/tests/custom-css.mdx
@@ -1,0 +1,114 @@
+---
+title: Custom CSS
+description: Test page for swatch grid, icon grid, mermaid in content, and scroll-to-top.
+sidebar:
+  order: 109
+  label: Custom CSS
+---
+
+## Color Swatches
+
+The swatch grid uses `--f5-*` CSS custom properties defined in `styles/custom.css`.
+
+<div class="swatch-grid">
+  <div class="swatch">
+    <div class="swatch-color text-light" style="background-color: var(--f5-red);">#e4002b</div>
+    <div class="swatch-label">F5 Red<code>--f5-red</code></div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color text-dark" style="background-color: var(--f5-tangerine);">#f29a36</div>
+    <div class="swatch-label">Tangerine<code>--f5-tangerine</code></div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color text-light" style="background-color: var(--f5-river);">#0e41aa</div>
+    <div class="swatch-label">River<code>--f5-river</code></div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color text-light" style="background-color: var(--f5-jade);">#009639</div>
+    <div class="swatch-label">Jade<code>--f5-jade</code></div>
+  </div>
+  <div class="swatch">
+    <div class="swatch-color text-light" style="background-color: var(--f5-eggplant);">#62228b</div>
+    <div class="swatch-label">Eggplant<code>--f5-eggplant</code></div>
+  </div>
+</div>
+
+## Icon Grid
+
+The icon grid uses the same pattern as the brand icons documentation page.
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="/f5-logo.svg" alt="F5 Logo" />
+    </div>
+    <div class="icon-card-label">F5 Logo</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="/f5-logo.svg" alt="F5 Logo" />
+    </div>
+    <div class="icon-card-label">F5 Logo (copy)</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="/f5-logo.svg" alt="F5 Logo" />
+    </div>
+    <div class="icon-card-label">F5 Logo (copy 2)</div>
+  </div>
+</div>
+
+## Mermaid in Content Collection
+
+This small diagram verifies the remark-mermaid plugin works inside the content collection.
+
+```mermaid
+flowchart LR
+  A[Theme] --> B[Build]
+  B --> C[Preview]
+```
+
+## Scroll-to-Top Trigger
+
+The following content provides enough vertical height to trigger the scroll-to-top button (36px override from `custom.css`). Scroll down and verify the button appears.
+
+### Section 1: Brand Colors
+
+The F5 brand palette includes Cloud Red, Tangerine, River, Raspberry, Jade, Eggplant, and Bay. Each primary color has four tint/shade variants for a total of 45 colors. The palette is used in graphics and illustrations, exploring unique and modern combinations as well as monochromatic contrasts.
+
+### Section 2: Typography
+
+The theme uses two font families: `neusaNextProWide` for H2-H3 headings and `proximaNova` for body text and H4-H6. Headings H4 and below are set in uppercase with letter-spacing for visual hierarchy.
+
+### Section 3: Code Styling
+
+Code blocks use Expressive Code with a custom macOS iTerm-style terminal header. The terminal header has a `#323232` background with traffic light SVG dots. Dark mode terminal bodies use `#1a1b26`.
+
+### Section 4: Aside Components
+
+Asides (note, tip, caution, danger) have rounded corners at 0.75rem and a layered box shadow. Each type has a distinct border-left color for quick identification.
+
+### Section 5: Mermaid Integration
+
+Mermaid diagrams are rendered via a remark plugin that converts fenced code blocks to `<div class="mermaid-container">` wrappers. The container forces white SVG backgrounds for dark mode compatibility.
+
+### Section 6: Dark Mode
+
+Dark mode is the Starlight default (bare `:root`). Light mode uses `:root[data-theme='light']`. The gray scale is semantic: `gray-1` is always primary text and `gray-6` is always subtle background, with actual brightness values swapping between modes.
+
+### Section 7: Accessibility
+
+All color pairings meet WCAG AA contrast requirements. Body text achieves 16.3:1 in dark mode and 11.6:1 in light mode. Accent links achieve 5.6:1 in dark and 4.6:1 in light.
+
+### Section 8: Component Library
+
+Starlight provides Cards, CardGrid, LinkCard, Tabs, Steps, FileTree, Icon, Badge, and Aside components. All are exercised in this test suite to verify theme compatibility.
+
+## Theme Checks
+
+- `.swatch` border uses `--sl-color-gray-5`
+- `.swatch-label` background uses `--sl-color-gray-6`
+- `.icon-card-image` background is `--sl-color-gray-7` in light, `--sl-color-gray-6` in dark
+- Dark mode SVGs in icon cards have `filter: invert(1)` applied
+- Scroll-to-top button appears after scrolling, sized at 36px
+- Mermaid diagram renders correctly inside the content collection

--- a/src/content/docs/tests/index.mdx
+++ b/src/content/docs/tests/index.mdx
@@ -1,0 +1,31 @@
+---
+title: Theme Test Suite
+description: Visual validation pages that exercise every theme feature during build.
+sidebar:
+  order: 100
+  label: Overview
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+This test suite provides live validation pages for the f5xc-docs-theme. Each page exercises a specific set of theme features so you can verify rendering after changes.
+
+## How to use
+
+1. Run `npx astro dev` for hot-reload development, or `npx astro build && npx astro preview` for a production build.
+2. Visit each test page below and verify the components render correctly.
+3. Toggle dark/light theme via Starlight's built-in switcher on every page to check both modes.
+
+## Test Pages
+
+<CardGrid>
+  <LinkCard title="Asides" href="/tests/asides/" description="All 4 aside types, custom titles, rich content inside asides." />
+  <LinkCard title="Tabs & Steps" href="/tests/tabs-and-steps/" description="Tabs, syncKey, icons, and Steps component." />
+  <LinkCard title="Cards" href="/tests/cards/" description="Card, CardGrid, stagger layout, and LinkCard." />
+  <LinkCard title="Badges" href="/tests/badges/" description="Badge variants, sizes, and heading badges plugin." />
+  <LinkCard title="Code Blocks" href="/tests/code-blocks/" description="Languages, terminal mode, line highlights, and diff." />
+  <LinkCard title="Mermaid Diagrams" href="/tests/mermaid-diagrams/" description="Flowchart, sequence, pie, class, state, and gantt diagrams." />
+  <LinkCard title="Typography" href="/tests/typography/" description="Headings, text styles, lists, blockquotes, and footnotes." />
+  <LinkCard title="Tables & Images" href="/tests/tables-and-images/" description="Tables, image zoom, FileTree, and Icon." />
+  <LinkCard title="Custom CSS" href="/tests/custom-css/" description="Swatch grid, icon grid, scroll-to-top trigger." />
+</CardGrid>

--- a/src/content/docs/tests/mermaid-diagrams.mdx
+++ b/src/content/docs/tests/mermaid-diagrams.mdx
@@ -1,0 +1,107 @@
+---
+title: Mermaid Diagrams
+description: Test page for Mermaid diagram types rendered via the remark-mermaid plugin.
+sidebar:
+  order: 106
+  label: Mermaid
+---
+
+## Flowchart
+
+```mermaid
+flowchart LR
+  A[User Request] --> B{WAF Check}
+  B -->|Pass| C[Origin Server]
+  B -->|Block| D[403 Forbidden]
+  C --> E[Response]
+```
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant LB as Load Balancer
+  participant App as Application
+  participant DB as Database
+
+  Client->>LB: HTTPS Request
+  LB->>App: Forward Request
+  App->>DB: Query Data
+  DB-->>App: Return Results
+  App-->>LB: Response
+  LB-->>Client: HTTPS Response
+```
+
+## Pie Chart
+
+```mermaid
+pie title Traffic Distribution
+  "North America" : 45
+  "Europe" : 30
+  "Asia Pacific" : 20
+  "Other" : 5
+```
+
+## Class Diagram
+
+```mermaid
+classDiagram
+  class LoadBalancer {
+    +String name
+    +String domain
+    +addOriginPool()
+    +removeOriginPool()
+  }
+  class OriginPool {
+    +String name
+    +List~Origin~ origins
+    +healthCheck()
+  }
+  class Origin {
+    +String address
+    +int port
+    +boolean healthy
+  }
+  LoadBalancer --> OriginPool
+  OriginPool --> Origin
+```
+
+## State Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> Pending
+  Pending --> Active : approve
+  Pending --> Rejected : reject
+  Active --> Suspended : suspend
+  Suspended --> Active : reactivate
+  Active --> [*] : delete
+  Rejected --> [*]
+```
+
+## Gantt Chart
+
+```mermaid
+gantt
+  title Deployment Timeline
+  dateFormat YYYY-MM-DD
+  section Planning
+    Requirements     :a1, 2025-01-01, 14d
+    Design           :a2, after a1, 10d
+  section Development
+    Implementation   :b1, after a2, 21d
+    Testing          :b2, after b1, 14d
+  section Release
+    Staging Deploy   :c1, after b2, 3d
+    Production Deploy :c2, after c1, 2d
+```
+
+## Theme Checks
+
+- `.mermaid-container` has white SVG background in dark mode
+- Container border uses `--sl-color-gray-5`
+- Container has 0.75rem border radius and layered box shadow
+- `rect` and `polygon` elements have forced white fill in dark mode
+- Diagrams are readable in both light and dark themes
+- Mermaid CDN script loads and renders SVGs on page load

--- a/src/content/docs/tests/tables-and-images.mdx
+++ b/src/content/docs/tests/tables-and-images.mdx
@@ -1,0 +1,82 @@
+---
+title: Tables & Images
+description: Test page for tables, image zoom, FileTree, and Icon components.
+sidebar:
+  order: 108
+  label: Tables & Images
+---
+
+import { FileTree, Icon } from '@astrojs/starlight/components';
+
+## Simple Table
+
+| Feature | Status | Priority |
+|---------|--------|----------|
+| Dark mode | Supported | High |
+| Image zoom | Supported | Medium |
+| Mermaid diagrams | Supported | Medium |
+| Heading badges | Supported | Low |
+
+## Table with Alignment and Code
+
+| Property | Type | Default | Description |
+|:---------|:----:|--------:|:------------|
+| `title` | `string` | — | Page title displayed in the header |
+| `description` | `string` | `""` | Meta description for SEO |
+| `sidebar.order` | `number` | `0` | Sort order in the sidebar |
+| `sidebar.badge` | `object` | `null` | Badge shown next to sidebar label |
+| `template` | `"doc" \| "splash"` | `"doc"` | Page layout template |
+
+## Image
+
+The image below tests the `starlight-image-zoom` plugin. Click to zoom.
+
+![GitHub Avatar](/github-avatar.png)
+
+## File Tree
+
+<FileTree>
+- src/
+  - content/
+    - docs/
+      - index.mdx
+      - tests/
+        - **index.mdx** Overview
+        - asides.mdx
+        - tabs-and-steps.mdx
+        - cards.mdx
+        - badges.mdx
+        - code-blocks.mdx
+        - mermaid-diagrams.mdx
+        - typography.mdx
+        - tables-and-images.mdx
+        - custom-css.mdx
+  - plugins/
+    - remark-mermaid.mjs
+- styles/
+  - custom.css
+- astro.config.mjs
+- package.json
+</FileTree>
+
+## Icons
+
+Starlight provides built-in icons via the `<Icon>` component.
+
+<Icon name="star" size="1.5rem" /> Star
+<Icon name="rocket" size="1.5rem" /> Rocket
+<Icon name="heart" size="1.5rem" /> Heart
+<Icon name="setting" size="1.5rem" /> Setting
+<Icon name="pencil" size="1.5rem" /> Pencil
+<Icon name="document" size="1.5rem" /> Document
+<Icon name="open-book" size="1.5rem" /> Open Book
+<Icon name="laptop" size="1.5rem" /> Laptop
+
+## Theme Checks
+
+- Table border colors adapt between light and dark modes
+- Table header row has a distinct background
+- Image zoom overlay works on click (starlight-image-zoom)
+- FileTree background uses theme-appropriate colors
+- Icons inherit the current text color
+- Table cells with `code` render correctly

--- a/src/content/docs/tests/tabs-and-steps.mdx
+++ b/src/content/docs/tests/tabs-and-steps.mdx
@@ -1,0 +1,118 @@
+---
+title: Tabs & Steps
+description: Test page for Tabs, synced tabs, and Steps components.
+sidebar:
+  order: 102
+  label: Tabs & Steps
+---
+
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+
+## Basic Tabs
+
+<Tabs>
+  <TabItem label="Overview">
+    This is the overview tab content. It contains plain text to verify basic tab rendering.
+  </TabItem>
+  <TabItem label="Details">
+    This is the details tab. Switching between tabs should be instant with no page reload.
+  </TabItem>
+</Tabs>
+
+## Tabs with Mixed Content
+
+<Tabs>
+  <TabItem label="Text">
+    Plain paragraph content in the first tab.
+  </TabItem>
+  <TabItem label="Code">
+    ```javascript
+    const greeting = "Hello from a code block inside a tab!";
+    console.log(greeting);
+    ```
+  </TabItem>
+  <TabItem label="List">
+    - Item one inside a tab
+    - Item two with **bold text**
+    - Item three with `inline code`
+  </TabItem>
+</Tabs>
+
+## Synced Tabs
+
+These two tab groups share `syncKey="pkg"`. Selecting a tab in one group should update the other.
+
+**Install command:**
+
+<Tabs syncKey="pkg">
+  <TabItem label="npm">
+    ```bash
+    npm install f5xc-docs-theme
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm add f5xc-docs-theme
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn add f5xc-docs-theme
+    ```
+  </TabItem>
+</Tabs>
+
+**Run command:**
+
+<Tabs syncKey="pkg">
+  <TabItem label="npm">
+    ```bash
+    npm run dev
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm dev
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn dev
+    ```
+  </TabItem>
+</Tabs>
+
+## Steps
+
+<Steps>
+
+1. **Clone the repository**
+
+   ```bash
+   git clone https://github.com/example/repo.git
+   cd repo
+   ```
+
+2. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+3. **Start the dev server**
+
+   ```bash
+   npm run dev
+   ```
+
+   The site will be available at `http://localhost:4321`.
+
+</Steps>
+
+## Theme Checks
+
+- Tab active indicator color uses the accent color
+- Step connector line is visible between numbered steps
+- Step numbers have adequate contrast in both light and dark modes
+- Synced tabs stay in sync when switching between groups
+- Code blocks inside tabs render with proper syntax highlighting

--- a/src/content/docs/tests/typography.mdx
+++ b/src/content/docs/tests/typography.mdx
@@ -1,0 +1,104 @@
+---
+title: Typography
+description: Test page for headings, text styles, lists, blockquotes, and footnotes.
+sidebar:
+  order: 107
+  label: Typography
+---
+
+## Heading Level 2
+
+### Heading Level 3
+
+#### Heading Level 4
+
+##### Heading Level 5
+
+###### Heading Level 6
+
+## Text Styles
+
+This is **bold text** for emphasis.
+
+This is *italic text* for subtle emphasis.
+
+This is ~~strikethrough text~~ for deprecated content.
+
+This is `inline code` for technical references.
+
+This is ***bold italic text*** for strong emphasis.
+
+This is a combination: **bold with `inline code` inside** and *italic with `code` inside*.
+
+## Ordered List
+
+1. First item in the ordered list
+2. Second item with **bold text**
+3. Third item with `inline code`
+4. Fourth item with a [link to Astro](https://astro.build)
+
+## Unordered List
+
+- First bullet point
+- Second bullet with **emphasis**
+- Third bullet with `code reference`
+- Fourth bullet with a [link](https://starlight.astro.build)
+
+## Nested Lists
+
+1. Top-level ordered item
+   - Nested unordered item A
+   - Nested unordered item B
+     1. Deep nested ordered item
+     2. Another deep nested item
+   - Back to first nesting level
+2. Second top-level item
+   - Another nested item
+
+## Blockquotes
+
+> This is a single-line blockquote.
+
+> This is a multi-line blockquote.
+>
+> It spans multiple paragraphs and can contain **bold**, *italic*, and `code` formatting.
+
+> Nested blockquotes:
+>
+> > This is a nested blockquote inside the outer one.
+> >
+> > It can contain its own formatting.
+
+## Horizontal Rule
+
+Content above the rule.
+
+---
+
+Content below the rule.
+
+## Links
+
+- Internal link: [Back to test suite overview](/tests/)
+- External link: [Starlight Documentation](https://starlight.astro.build)
+- Link with title: [Astro](https://astro.build "Astro Framework Homepage")
+
+## Footnotes
+
+Here is a sentence with a footnote reference[^1].
+
+And another sentence with a different footnote[^2].
+
+[^1]: This is the first footnote content. It appears at the bottom of the page.
+
+[^2]: This is the second footnote. It can contain **formatting** and `code`.
+
+## Theme Checks
+
+- H2 and H3 use `neusaNextProWide` font family with weight 700/500
+- H4, H5, H6 use `proximaNova` font, uppercase, with letter-spacing 0.05em
+- Link accent color is `#f06680` in dark mode, `#e4002b` in light mode
+- Inline code has a background tint from `--sl-color-gray-5`
+- Blockquote border-left is visible in both themes
+- Footnote references are superscripted and linked
+- Horizontal rule has appropriate contrast


### PR DESCRIPTION
## Summary

- Add `src/content.config.ts` with `docsLoader()` + `docsSchema()` required by Starlight 0.37.6 — fixes silent build failure where 0 HTML doc pages were generated
- Add 10 MDX test pages in `src/content/docs/tests/` exercising all theme features: asides, tabs, steps, cards, badges, code blocks, mermaid diagrams, typography, tables, images, FileTree, Icon, swatch grid, icon grid, and scroll-to-top

## Test plan

- [ ] `npx astro build` generates all 12 pages without errors
- [ ] `npx astro preview` — visually inspect each test page
- [ ] Toggle dark/light theme on every page
- [ ] Verify mermaid diagrams render (CDN script loads, SVGs appear)
- [ ] Verify image zoom works (click github-avatar image)
- [ ] Verify synced tabs stay in sync across tab groups
- [ ] Verify heading badges render inline with headings
- [ ] Verify sidebar shows "Tests" group with all 10 pages in order

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)