### PR TITLE
fix: Load Mermaid CDN via Starlight head config and fix avatar image path

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -130,6 +130,13 @@ export default defineConfig({
             : [],
         }),
       ],
+      head: [
+        {
+          tag: 'script',
+          attrs: { type: 'module' },
+          content: `import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'; mermaid.initialize({ startOnLoad: true, theme: 'neutral' });`,
+        },
+      ],
       logo: {
         src: 'f5xc-docs-theme/assets/github-avatar.png',
       },

--- a/docs/09-components.mdx
+++ b/docs/09-components.mdx
@@ -308,7 +308,7 @@ Check the sidebar: this page has a "New" badge with the `tip` variant applied vi
 
 The image below tests the `starlight-image-zoom` plugin. Click to zoom.
 
-![GitHub Avatar](/github-avatar.png)
+![GitHub Avatar](../assets/github-avatar.png)
 
 ## File Tree
 

--- a/src/plugins/remark-mermaid.mjs
+++ b/src/plugins/remark-mermaid.mjs
@@ -2,12 +2,9 @@ import { visit } from 'unist-util-visit';
 
 export default function remarkMermaid() {
   return (tree) => {
-    let hasMermaid = false;
-
     visit(tree, 'code', (node, index, parent) => {
       if (node.lang !== 'mermaid') return;
 
-      hasMermaid = true;
       const escaped = node.value
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
@@ -19,14 +16,7 @@ export default function remarkMermaid() {
       };
     });
 
-    if (hasMermaid) {
-      tree.children.push({
-        type: 'html',
-        value: `<script type="module">
-import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
-</script>`,
-      });
-    }
+    // Note: Mermaid CDN script is loaded via Starlight head config in astro.config.mjs.
+    // Script injection via remark HTML nodes is stripped by MDX/Astro for security.
   };
 }


### PR DESCRIPTION
## Summary

- Move Mermaid CDN script from remark plugin injection to Starlight `head` config — fixes diagrams not rendering because MDX/Astro strips `<script>` tags from remark HTML nodes
- Fix `github-avatar.png` path in components page to use relative import (`../assets/github-avatar.png`) so it resolves correctly regardless of site base path
- Clean up unused `hasMermaid` variable from remark-mermaid plugin

Closes #203

## Test plan

- [ ] Verify Mermaid diagrams render as SVGs on the live site (`/10-mermaid/`)
- [ ] Verify github-avatar.png loads without 404 on Components page (`/09-components/`)
- [ ] Verify `npx astro build` passes
- [ ] Check Mermaid CDN script is present in built HTML (`grep mermaid dist/index.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)