### PR TITLE
fix: Use public URL for avatar image in components demo

### DIFF
--- a/docs/09-components.mdx
+++ b/docs/09-components.mdx
@@ -308,7 +308,7 @@ Check the sidebar: this page has a "New" badge with the `tip` variant applied vi
 
 The image below tests the `starlight-image-zoom` plugin. Click to zoom.
 
-![GitHub Avatar](../assets/github-avatar.png)
+![GitHub Avatar](https://github.com/robinmordasiewicz.png)
 
 ## File Tree
 


### PR DESCRIPTION
## Summary

- Fix Docker builder failure: relative path `../assets/github-avatar.png` resolves to wrong location when docs are at `src/content/docs/` in the builder
- Use public GitHub avatar URL instead, which works in both local and Docker builds

Closes #205

## Test plan

- [ ] Verify `npx astro build` passes locally
- [ ] Verify GitHub Pages Deploy workflow succeeds
- [ ] Verify image renders on Components page (`/09-components/`)
- [ ] Verify image-zoom plugin works on the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)