### PR TITLE
fix: defensive CSS to prevent Scalar body pollution

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -403,3 +403,15 @@ h4, h5, h6 {
   cy: 18;
   r: 16;
 }
+
+/* ===== Prevent Scalar API Viewer Body Pollution ===== */
+body.dark-mode,
+body.light-mode {
+  background-color: var(--sl-color-bg) !important;
+  color: var(--sl-color-text) !important;
+}
+body {
+  --scalar-background-1: unset;
+  --scalar-background-2: unset;
+  --scalar-background-3: unset;
+}


### PR DESCRIPTION
## Summary
- Override `body.dark-mode` and `body.light-mode` to use Starlight's `--sl-color-bg` and `--sl-color-text`
- Unset Scalar's `--scalar-background-*` custom properties on body
- Acts as safety net for timing gaps between Scalar adding body classes and MutationObserver cleanup

Companion PR: robinmordasiewicz/f5xc-docs-builder#119 (component changes)

Closes #207

## Test plan
- [ ] With only this CSS (before builder PR), Starlight light mode should at minimum not show black background
- [ ] With both PRs merged, full theme switching works end-to-end
- [ ] Non-API pages unaffected by new CSS rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)