### PR TITLE
fix: clean up npm package contents for release readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ dist/
 .astro/
 site/
 
+# Screenshots (root-level only)
+/*.png
+
 # Python
 __pycache__/
 *.py[cod]

--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,4 @@ docs/
 .gitignore
 CLAUDE.md
 CONTRIBUTING.md
-README.md
-LICENSE
 release.config.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "starlight-scroll-to-top": "^0.4.0",
         "starlight-videos": "^0.3.1"
       },
+      "devDependencies": {
+        "@playwright/test": "^1.50.0"
+      },
       "peerDependencies": {
         "@astrojs/starlight": ">=0.34.0"
       }
@@ -1745,6 +1748,22 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -6760,6 +6779,53 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -29,12 +29,11 @@
   "files": [
     "index.ts",
     "route-middleware.ts",
-    "astro.config.mjs",
     "fonts/",
     "styles/",
     "assets/",
     "components/",
-    "src/"
+    "src/plugins/"
   ],
   "keywords": [
     "starlight",


### PR DESCRIPTION
## Summary
- Remove `README.md` and `LICENSE` from `.npmignore` so they appear in the published npm package (fixes missing npmjs.com README and license distribution)
- Remove `astro.config.mjs` from `files` array (demo site config not needed by consumers)
- Narrow `src/` to `src/plugins/` in `files` array to exclude demo content (`index.mdx`, `content.config.ts`)
- Add `/*.png` to `.gitignore` and remove leftover screenshot PNGs from repo root

## Test plan
- [x] `npm pack --dry-run` confirms `README.md` and `LICENSE` are included
- [x] `npm pack --dry-run` confirms `astro.config.mjs` is excluded
- [x] `npm pack --dry-run` confirms `src/content/` files are excluded
- [x] `npm pack --dry-run` confirms `src/plugins/remark-mermaid.mjs` is still included
- [x] All 14 Playwright visual regression tests pass
- [ ] CI passes

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)