### PR TITLE
fix: restore astro.config.mjs and src/ to npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
   "files": [
     "index.ts",
     "route-middleware.ts",
+    "astro.config.mjs",
     "fonts/",
     "styles/",
     "assets/",
     "components/",
-    "src/plugins/"
+    "src/"
   ],
   "keywords": [
     "starlight",


### PR DESCRIPTION
## Summary
- Restores `astro.config.mjs` and `src/` (was narrowed to `src/plugins/`) to the npm `files` field
- PR #216 removed these, breaking the downstream builder which copies `astro.config.mjs` and `src/content.config.ts` from the theme at runtime
- The theme is the single source of truth for Astro configuration

## Test plan
- [ ] Verify `npm pack --dry-run` includes `astro.config.mjs` and `src/content.config.ts`
- [ ] Verify downstream builder can copy configs from updated theme package

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)