### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@ dist/
 .astro/
 site/
 
-# Screenshots (root-level only)
-/*.png
-
 # Python
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Closes #219

Synced managed files from `robinmordasiewicz/f5xc-template` canonical source:

- .gitignore