### PR TITLE
fix: correct import path and align mermaid plugin with builder contract

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,3 @@
-import { createF5xcDocsConfig } from './config.ts';
+import { createF5xcDocsConfig } from 'f5xc-docs-theme/config';
 
 export default createF5xcDocsConfig();

--- a/src/plugins/remark-mermaid.mjs
+++ b/src/plugins/remark-mermaid.mjs
@@ -12,11 +12,9 @@ export default function remarkMermaid() {
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;');
 
-      const encoded = encodeURIComponent(node.value);
-
       parent.children[index] = {
         type: 'html',
-        value: `<div class="mermaid-container"><pre class="mermaid" data-mermaid-src="${encoded}">${escaped}</pre></div>`,
+        value: `<div class="mermaid-container" data-mermaid-src="${escaped}"><pre class="mermaid">${escaped}</pre></div>`,
       };
     });
 


### PR DESCRIPTION
## Summary

- Fix `astro.config.mjs` import from `./config.ts` (relative, breaks in builder) to `f5xc-docs-theme/config` (self-referencing package export, works everywhere)
- Align `remark-mermaid.mjs` with the builder's `placeholder-dom.ts` contract: move `data-mermaid-src` from `<pre>` to `.mermaid-container` div, use HTML-escaping instead of `encodeURIComponent`

## Test plan

- [ ] `npx astro build` succeeds with all plugins loaded
- [ ] Inspect build output HTML — `data-mermaid-src` is on `.mermaid-container` div, not `<pre>`
- [ ] After merge + release, builder's GitHub Pages Deploy CI passes (currently broken: run #21956990390)

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)