### PR TITLE
fix: use root-relative paths for brand-icons SVG images

### DIFF
--- a/docs/06-brand-icons.mdx
+++ b/docs/06-brand-icons.mdx
@@ -12,109 +12,109 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-admin.svg" alt="Admin" />
+      <img src="/brand-icons/f5-icon-ai-admin.svg" alt="Admin" />
     </div>
     <div class="icon-card-label">Admin</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-agentic.svg" alt="Agentic" />
+      <img src="/brand-icons/f5-icon-ai-agentic.svg" alt="Agentic" />
     </div>
     <div class="icon-card-label">Agentic</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-ai-agentic-workflow.svg" alt="Agentic Workflow" />
+      <img src="/brand-icons/f5-ai-agentic-workflow.svg" alt="Agentic Workflow" />
     </div>
     <div class="icon-card-label">Agentic Workflow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-app-ops.svg" alt="App Ops" />
+      <img src="/brand-icons/f5-icon-ai-app-ops.svg" alt="App Ops" />
     </div>
     <div class="icon-card-label">App Ops</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-ai-auto-red-team.svg" alt="Auto Red Team" />
+      <img src="/brand-icons/f5-ai-auto-red-team.svg" alt="Auto Red Team" />
     </div>
     <div class="icon-card-label">Auto Red Team</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-bad-actor-skull.svg" alt="Bad Actor Skull" />
+      <img src="/brand-icons/f5-icon-ai-bad-actor-skull.svg" alt="Bad Actor Skull" />
     </div>
     <div class="icon-card-label">Bad Actor Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-ai-client-intelligence.svg" alt="Client Intelligence" />
+      <img src="/brand-icons/f5-ai-client-intelligence.svg" alt="Client Intelligence" />
     </div>
     <div class="icon-card-label">Client Intelligence</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-cloud-load-balancing.svg" alt="Cloud Load Balancing" />
+      <img src="/brand-icons/f5-icon-ai-cloud-load-balancing.svg" alt="Cloud Load Balancing" />
     </div>
     <div class="icon-card-label">Cloud Load Balancing</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-cloud-scale.svg" alt="Cloud Scale" />
+      <img src="/brand-icons/f5-icon-ai-cloud-scale.svg" alt="Cloud Scale" />
     </div>
     <div class="icon-card-label">Cloud Scale</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-data-ingestion.svg" alt="Data Ingestion" />
+      <img src="/brand-icons/f5-icon-ai-data-ingestion.svg" alt="Data Ingestion" />
     </div>
     <div class="icon-card-label">Data Ingestion</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-ai-data-leakage.svg" alt="Data Leakage" />
+      <img src="/brand-icons/f5-ai-data-leakage.svg" alt="Data Leakage" />
     </div>
     <div class="icon-card-label">Data Leakage</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-ai-data-shield.svg" alt="Data Shield" />
+      <img src="/brand-icons/f5-ai-data-shield.svg" alt="Data Shield" />
     </div>
     <div class="icon-card-label">Data Shield</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-device-laptop-brain.svg" alt="Device Laptop Brain" />
+      <img src="/brand-icons/f5-icon-ai-device-laptop-brain.svg" alt="Device Laptop Brain" />
     </div>
     <div class="icon-card-label">Device Laptop Brain</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-edge-network.svg" alt="Edge Network" />
+      <img src="/brand-icons/f5-icon-ai-edge-network.svg" alt="Edge Network" />
     </div>
     <div class="icon-card-label">Edge Network</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-factory.svg" alt="Factory" />
+      <img src="/brand-icons/f5-icon-ai-factory.svg" alt="Factory" />
     </div>
     <div class="icon-card-label">Factory</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-finance.svg" alt="Finance" />
+      <img src="/brand-icons/f5-icon-ai-finance.svg" alt="Finance" />
     </div>
     <div class="icon-card-label">Finance</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-finance-arrows.svg" alt="Finance Arrows" />
+      <img src="/brand-icons/f5-icon-ai-finance-arrows.svg" alt="Finance Arrows" />
     </div>
     <div class="icon-card-label">Finance Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-firewall.svg" alt="Firewall" />
+      <img src="/brand-icons/f5-icon-ai-firewall.svg" alt="Firewall" />
     </div>
     <div class="icon-card-label">Firewall</div>
   </div>
@@ -126,169 +126,169 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-governance.svg" alt="Governance" />
+      <img src="/brand-icons/f5-icon-ai-governance.svg" alt="Governance" />
     </div>
     <div class="icon-card-label">Governance</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-graph-data.svg" alt="Graph Data" />
+      <img src="/brand-icons/f5-icon-ai-graph-data.svg" alt="Graph Data" />
     </div>
     <div class="icon-card-label">Graph Data</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-guardrails.svg" alt="Guardrails" />
+      <img src="/brand-icons/f5-icon-ai-guardrails.svg" alt="Guardrails" />
     </div>
     <div class="icon-card-label">Guardrails</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-health.svg" alt="Health" />
+      <img src="/brand-icons/f5-icon-ai-health.svg" alt="Health" />
     </div>
     <div class="icon-card-label">Health</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-ai-insights.svg" alt="Insights" />
+      <img src="/brand-icons/f5-ai-insights.svg" alt="Insights" />
     </div>
     <div class="icon-card-label">Insights</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-intergrated-no.svg" alt="Intergrated No" />
+      <img src="/brand-icons/f5-icon-ai-intergrated-no.svg" alt="Intergrated No" />
     </div>
     <div class="icon-card-label">Intergrated No</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-intergrated-yes.svg" alt="Intergrated Yes" />
+      <img src="/brand-icons/f5-icon-ai-intergrated-yes.svg" alt="Intergrated Yes" />
     </div>
     <div class="icon-card-label">Intergrated Yes</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-ai-llm-observability.svg" alt="Llm Observability" />
+      <img src="/brand-icons/f5-ai-llm-observability.svg" alt="Llm Observability" />
     </div>
     <div class="icon-card-label">Llm Observability</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-load-balancing.svg" alt="Load Balancing" />
+      <img src="/brand-icons/f5-icon-ai-load-balancing.svg" alt="Load Balancing" />
     </div>
     <div class="icon-card-label">Load Balancing</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-machine-learning.svg" alt="Machine Learning" />
+      <img src="/brand-icons/f5-icon-ai-machine-learning.svg" alt="Machine Learning" />
     </div>
     <div class="icon-card-label">Machine Learning</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-model-fine-tuning.svg" alt="Model Fine Tuning" />
+      <img src="/brand-icons/f5-icon-ai-model-fine-tuning.svg" alt="Model Fine Tuning" />
     </div>
     <div class="icon-card-label">Model Fine Tuning</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-model-inference.svg" alt="Model Inference" />
+      <img src="/brand-icons/f5-icon-ai-model-inference.svg" alt="Model Inference" />
     </div>
     <div class="icon-card-label">Model Inference</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-model-training.svg" alt="Model Training" />
+      <img src="/brand-icons/f5-icon-ai-model-training.svg" alt="Model Training" />
     </div>
     <div class="icon-card-label">Model Training</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-monitor-health.svg" alt="Monitor Health" />
+      <img src="/brand-icons/f5-icon-ai-monitor-health.svg" alt="Monitor Health" />
     </div>
     <div class="icon-card-label">Monitor Health</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-network-2.svg" alt="Network 2" />
+      <img src="/brand-icons/f5-icon-ai-network-2.svg" alt="Network 2" />
     </div>
     <div class="icon-card-label">Network 2</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-networking.svg" alt="Networking" />
+      <img src="/brand-icons/f5-icon-ai-networking.svg" alt="Networking" />
     </div>
     <div class="icon-card-label">Networking</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-orchestration.svg" alt="Orchestration" />
+      <img src="/brand-icons/f5-icon-ai-orchestration.svg" alt="Orchestration" />
     </div>
     <div class="icon-card-label">Orchestration</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-performance-fast.svg" alt="Performance Fast" />
+      <img src="/brand-icons/f5-icon-ai-performance-fast.svg" alt="Performance Fast" />
     </div>
     <div class="icon-card-label">Performance Fast</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-performance-slow.svg" alt="Performance Slow" />
+      <img src="/brand-icons/f5-icon-ai-performance-slow.svg" alt="Performance Slow" />
     </div>
     <div class="icon-card-label">Performance Slow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-post-quantum-cryptography.svg" alt="Post Quantum Cryptography" />
+      <img src="/brand-icons/f5-icon-ai-post-quantum-cryptography.svg" alt="Post Quantum Cryptography" />
     </div>
     <div class="icon-card-label">Post Quantum Cryptography</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-ai-prompt-injection.svg" alt="Prompt Injection" />
+      <img src="/brand-icons/f5-ai-prompt-injection.svg" alt="Prompt Injection" />
     </div>
     <div class="icon-card-label">Prompt Injection</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-provisioning.svg" alt="Provisioning" />
+      <img src="/brand-icons/f5-icon-ai-provisioning.svg" alt="Provisioning" />
     </div>
     <div class="icon-card-label">Provisioning</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-rag.svg" alt="Rag" />
+      <img src="/brand-icons/f5-icon-ai-rag.svg" alt="Rag" />
     </div>
     <div class="icon-card-label">Rag</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-red-team.svg" alt="Red Team" />
+      <img src="/brand-icons/f5-icon-ai-red-team.svg" alt="Red Team" />
     </div>
     <div class="icon-card-label">Red Team</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-ai-repetition-detection.svg" alt="Repetition Detection" />
+      <img src="/brand-icons/f5-ai-repetition-detection.svg" alt="Repetition Detection" />
     </div>
     <div class="icon-card-label">Repetition Detection</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-scale.svg" alt="Scale" />
+      <img src="/brand-icons/f5-icon-ai-scale.svg" alt="Scale" />
     </div>
     <div class="icon-card-label">Scale</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-ai-security.svg" alt="Security" />
+      <img src="/brand-icons/f5-icon-ai-security.svg" alt="Security" />
     </div>
     <div class="icon-card-label">Security</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-ai-shadow-ai.svg" alt="Shadow Ai" />
+      <img src="/brand-icons/f5-ai-shadow-ai.svg" alt="Shadow Ai" />
     </div>
     <div class="icon-card-label">Shadow Ai</div>
   </div>
@@ -300,175 +300,175 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-adsp.svg" alt="Adsp" />
+      <img src="/brand-icons/f5-icon-app-adsp.svg" alt="Adsp" />
     </div>
     <div class="icon-card-label">Adsp</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-app.svg" alt="App" />
+      <img src="/brand-icons/f5-icon-app-app.svg" alt="App" />
     </div>
     <div class="icon-card-label">App</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-arrow-upload.svg" alt="Arrow Upload" />
+      <img src="/brand-icons/f5-icon-app-arrow-upload.svg" alt="Arrow Upload" />
     </div>
     <div class="icon-card-label">Arrow Upload</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-code.svg" alt="Code" />
+      <img src="/brand-icons/f5-icon-app-code.svg" alt="Code" />
     </div>
     <div class="icon-card-label">Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-consolidated.svg" alt="Consolidated" />
+      <img src="/brand-icons/f5-icon-app-consolidated.svg" alt="Consolidated" />
     </div>
     <div class="icon-card-label">Consolidated</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-consolidated-across.svg" alt="Consolidated Across" />
+      <img src="/brand-icons/f5-icon-app-consolidated-across.svg" alt="Consolidated Across" />
     </div>
     <div class="icon-card-label">Consolidated Across</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-consolidated-up.svg" alt="Consolidated Up" />
+      <img src="/brand-icons/f5-icon-app-consolidated-up.svg" alt="Consolidated Up" />
     </div>
     <div class="icon-card-label">Consolidated Up</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-delivery-fabric.svg" alt="Delivery Fabric" />
+      <img src="/brand-icons/f5-icon-app-delivery-fabric.svg" alt="Delivery Fabric" />
     </div>
     <div class="icon-card-label">Delivery Fabric</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-fast.svg" alt="Fast" />
+      <img src="/brand-icons/f5-icon-app-fast.svg" alt="Fast" />
     </div>
     <div class="icon-card-label">Fast</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-gear.svg" alt="Gear" />
+      <img src="/brand-icons/f5-icon-app-gear.svg" alt="Gear" />
     </div>
     <div class="icon-card-label">Gear</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-gear-ekg-heart.svg" alt="Gear Ekg Heart" />
+      <img src="/brand-icons/f5-icon-app-gear-ekg-heart.svg" alt="Gear Ekg Heart" />
     </div>
     <div class="icon-card-label">Gear Ekg Heart</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-hyperconverged.svg" alt="Hyperconverged" />
+      <img src="/brand-icons/f5-icon-app-hyperconverged.svg" alt="Hyperconverged" />
     </div>
     <div class="icon-card-label">Hyperconverged</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-iapp.svg" alt="Iapp" />
+      <img src="/brand-icons/f5-icon-app-iapp.svg" alt="Iapp" />
     </div>
     <div class="icon-card-label">Iapp</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-kubernetes.svg" alt="Kubernetes" />
+      <img src="/brand-icons/f5-icon-app-kubernetes.svg" alt="Kubernetes" />
     </div>
     <div class="icon-card-label">Kubernetes</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-lock.svg" alt="Lock" />
+      <img src="/brand-icons/f5-icon-app-lock.svg" alt="Lock" />
     </div>
     <div class="icon-card-label">Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-magnifying-health.svg" alt="Magnifying Health" />
+      <img src="/brand-icons/f5-icon-app-magnifying-health.svg" alt="Magnifying Health" />
     </div>
     <div class="icon-card-label">Magnifying Health</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-migration.svg" alt="Migration" />
+      <img src="/brand-icons/f5-icon-app-migration.svg" alt="Migration" />
     </div>
     <div class="icon-card-label">Migration</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-migration-multi.svg" alt="Migration Multi" />
+      <img src="/brand-icons/f5-icon-app-migration-multi.svg" alt="Migration Multi" />
     </div>
     <div class="icon-card-label">Migration Multi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-rocket-deploy.svg" alt="Rocket Deploy" />
+      <img src="/brand-icons/f5-icon-app-rocket-deploy.svg" alt="Rocket Deploy" />
     </div>
     <div class="icon-card-label">Rocket Deploy</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-scale-up.svg" alt="Scale Up" />
+      <img src="/brand-icons/f5-icon-app-scale-up.svg" alt="Scale Up" />
     </div>
     <div class="icon-card-label">Scale Up</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-shield-check.svg" alt="Shield Check" />
+      <img src="/brand-icons/f5-icon-app-shield-check.svg" alt="Shield Check" />
     </div>
     <div class="icon-card-label">Shield Check</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-shield-clouds.svg" alt="Shield Clouds" />
+      <img src="/brand-icons/f5-icon-app-shield-clouds.svg" alt="Shield Clouds" />
     </div>
     <div class="icon-card-label">Shield Clouds</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-skull.svg" alt="Skull" />
+      <img src="/brand-icons/f5-icon-app-skull.svg" alt="Skull" />
     </div>
     <div class="icon-card-label">Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-slow.svg" alt="Slow" />
+      <img src="/brand-icons/f5-icon-app-slow.svg" alt="Slow" />
     </div>
     <div class="icon-card-label">Slow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-ve-cloud.svg" alt="Ve Cloud" />
+      <img src="/brand-icons/f5-icon-app-ve-cloud.svg" alt="Ve Cloud" />
     </div>
     <div class="icon-card-label">Ve Cloud</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-virtual.svg" alt="Virtual" />
+      <img src="/brand-icons/f5-icon-app-virtual.svg" alt="Virtual" />
     </div>
     <div class="icon-card-label">Virtual</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-virtual-edition.svg" alt="Virtual Edition" />
+      <img src="/brand-icons/f5-icon-app-virtual-edition.svg" alt="Virtual Edition" />
     </div>
     <div class="icon-card-label">Virtual Edition</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-virtual-edition-with-server.svg" alt="Virtual Edition With Server" />
+      <img src="/brand-icons/f5-icon-app-virtual-edition-with-server.svg" alt="Virtual Edition With Server" />
     </div>
     <div class="icon-card-label">Virtual Edition With Server</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-app-vulnerable.svg" alt="Vulnerable" />
+      <img src="/brand-icons/f5-icon-app-vulnerable.svg" alt="Vulnerable" />
     </div>
     <div class="icon-card-label">Vulnerable</div>
   </div>
@@ -480,355 +480,355 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-adc.svg" alt="Adc" />
+      <img src="/brand-icons/f5-icon-cloud-adc.svg" alt="Adc" />
     </div>
     <div class="icon-card-label">Adc</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-agnostic.svg" alt="Agnostic" />
+      <img src="/brand-icons/f5-icon-cloud-agnostic.svg" alt="Agnostic" />
     </div>
     <div class="icon-card-label">Agnostic</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-angled-arrows.svg" alt="Angled Arrows" />
+      <img src="/brand-icons/f5-icon-cloud-angled-arrows.svg" alt="Angled Arrows" />
     </div>
     <div class="icon-card-label">Angled Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-app.svg" alt="App" />
+      <img src="/brand-icons/f5-icon-cloud-app.svg" alt="App" />
     </div>
     <div class="icon-card-label">App</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-app-arrow.svg" alt="App Arrow" />
+      <img src="/brand-icons/f5-icon-cloud-app-arrow.svg" alt="App Arrow" />
     </div>
     <div class="icon-card-label">App Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-arrow-with-rotating-arrows.svg" alt="Arrow With Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-cloud-arrow-with-rotating-arrows.svg" alt="Arrow With Rotating Arrows" />
     </div>
     <div class="icon-card-label">Arrow With Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-binary-code.svg" alt="Binary Code" />
+      <img src="/brand-icons/f5-icon-cloud-binary-code.svg" alt="Binary Code" />
     </div>
     <div class="icon-card-label">Binary Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-blocks.svg" alt="Blocks" />
+      <img src="/brand-icons/f5-icon-cloud-blocks.svg" alt="Blocks" />
     </div>
     <div class="icon-card-label">Blocks</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-building.svg" alt="Building" />
+      <img src="/brand-icons/f5-icon-cloud-building.svg" alt="Building" />
     </div>
     <div class="icon-card-label">Building</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-clock-with-arrow.svg" alt="Clock With Arrow" />
+      <img src="/brand-icons/f5-icon-cloud-clock-with-arrow.svg" alt="Clock With Arrow" />
     </div>
     <div class="icon-card-label">Clock With Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-container-app.svg" alt="Container App" />
+      <img src="/brand-icons/f5-icon-cloud-container-app.svg" alt="Container App" />
     </div>
     <div class="icon-card-label">Container App</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-database.svg" alt="Database" />
+      <img src="/brand-icons/f5-icon-cloud-database.svg" alt="Database" />
     </div>
     <div class="icon-card-label">Database</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-database-with-arrow.svg" alt="Database With Arrow" />
+      <img src="/brand-icons/f5-icon-cloud-database-with-arrow.svg" alt="Database With Arrow" />
     </div>
     <div class="icon-card-label">Database With Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-distributed.svg" alt="Distributed" />
+      <img src="/brand-icons/f5-icon-cloud-distributed.svg" alt="Distributed" />
     </div>
     <div class="icon-card-label">Distributed</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-dns-load-balance.svg" alt="Dns Load Balance" />
+      <img src="/brand-icons/f5-icon-cloud-dns-load-balance.svg" alt="Dns Load Balance" />
     </div>
     <div class="icon-card-label">Dns Load Balance</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-document-code.svg" alt="Document Code" />
+      <img src="/brand-icons/f5-icon-cloud-document-code.svg" alt="Document Code" />
     </div>
     <div class="icon-card-label">Document Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-download.svg" alt="Download" />
+      <img src="/brand-icons/f5-icon-cloud-download.svg" alt="Download" />
     </div>
     <div class="icon-card-label">Download</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-download-upload.svg" alt="Download Upload" />
+      <img src="/brand-icons/f5-icon-cloud-download-upload.svg" alt="Download Upload" />
     </div>
     <div class="icon-card-label">Download Upload</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-edge-computing.svg" alt="Edge Computing" />
+      <img src="/brand-icons/f5-icon-cloud-edge-computing.svg" alt="Edge Computing" />
     </div>
     <div class="icon-card-label">Edge Computing</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-firewall.svg" alt="Firewall" />
+      <img src="/brand-icons/f5-icon-cloud-firewall.svg" alt="Firewall" />
     </div>
     <div class="icon-card-label">Firewall</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-id-card.svg" alt="Id Card" />
+      <img src="/brand-icons/f5-icon-cloud-id-card.svg" alt="Id Card" />
     </div>
     <div class="icon-card-label">Id Card</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-key.svg" alt="Key" />
+      <img src="/brand-icons/f5-icon-cloud-key.svg" alt="Key" />
     </div>
     <div class="icon-card-label">Key</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-kubernettes.svg" alt="Kubernettes" />
+      <img src="/brand-icons/f5-icon-cloud-kubernettes.svg" alt="Kubernettes" />
     </div>
     <div class="icon-card-label">Kubernettes</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-lock-app.svg" alt="Lock App" />
+      <img src="/brand-icons/f5-icon-cloud-lock-app.svg" alt="Lock App" />
     </div>
     <div class="icon-card-label">Lock App</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-lock-rotating-arrows.svg" alt="Lock Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-cloud-lock-rotating-arrows.svg" alt="Lock Rotating Arrows" />
     </div>
     <div class="icon-card-label">Lock Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-lock-virtual-app.svg" alt="Lock Virtual App" />
+      <img src="/brand-icons/f5-icon-cloud-lock-virtual-app.svg" alt="Lock Virtual App" />
     </div>
     <div class="icon-card-label">Lock Virtual App</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-media.svg" alt="Media" />
+      <img src="/brand-icons/f5-icon-cloud-media.svg" alt="Media" />
     </div>
     <div class="icon-card-label">Media</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-microservices.svg" alt="Microservices" />
+      <img src="/brand-icons/f5-icon-cloud-microservices.svg" alt="Microservices" />
     </div>
     <div class="icon-card-label">Microservices</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-migrate-upload-arrow.svg" alt="Migrate Upload Arrow" />
+      <img src="/brand-icons/f5-icon-cloud-migrate-upload-arrow.svg" alt="Migrate Upload Arrow" />
     </div>
     <div class="icon-card-label">Migrate Upload Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-money-arrow-down.svg" alt="Money Arrow Down" />
+      <img src="/brand-icons/f5-icon-cloud-money-arrow-down.svg" alt="Money Arrow Down" />
     </div>
     <div class="icon-card-label">Money Arrow Down</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-money-arrow-up.svg" alt="Money Arrow Up" />
+      <img src="/brand-icons/f5-icon-cloud-money-arrow-up.svg" alt="Money Arrow Up" />
     </div>
     <div class="icon-card-label">Money Arrow Up</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-multi.svg" alt="Multi" />
+      <img src="/brand-icons/f5-icon-cloud-multi.svg" alt="Multi" />
     </div>
     <div class="icon-card-label">Multi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-multi-app-container.svg" alt="Multi App Container" />
+      <img src="/brand-icons/f5-icon-cloud-multi-app-container.svg" alt="Multi App Container" />
     </div>
     <div class="icon-card-label">Multi App Container</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-multi-network.svg" alt="Multi Network" />
+      <img src="/brand-icons/f5-icon-cloud-multi-network.svg" alt="Multi Network" />
     </div>
     <div class="icon-card-label">Multi Network</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-multi-with-cog.svg" alt="Multi With Cog" />
+      <img src="/brand-icons/f5-icon-cloud-multi-with-cog.svg" alt="Multi With Cog" />
     </div>
     <div class="icon-card-label">Multi With Cog</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-multi-with-key.svg" alt="Multi With Key" />
+      <img src="/brand-icons/f5-icon-cloud-multi-with-key.svg" alt="Multi With Key" />
     </div>
     <div class="icon-card-label">Multi With Key</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-multi-with-lock.svg" alt="Multi With Lock" />
+      <img src="/brand-icons/f5-icon-cloud-multi-with-lock.svg" alt="Multi With Lock" />
     </div>
     <div class="icon-card-label">Multi With Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-multi-with-shield-checkmark.svg" alt="Multi With Shield Checkmark" />
+      <img src="/brand-icons/f5-icon-cloud-multi-with-shield-checkmark.svg" alt="Multi With Shield Checkmark" />
     </div>
     <div class="icon-card-label">Multi With Shield Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-network-connect.svg" alt="Network Connect" />
+      <img src="/brand-icons/f5-icon-cloud-network-connect.svg" alt="Network Connect" />
     </div>
     <div class="icon-card-label">Network Connect</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-network-signal.svg" alt="Network Signal" />
+      <img src="/brand-icons/f5-icon-cloud-network-signal.svg" alt="Network Signal" />
     </div>
     <div class="icon-card-label">Network Signal</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-nfs-apps.svg" alt="Nfs Apps" />
+      <img src="/brand-icons/f5-icon-cloud-nfs-apps.svg" alt="Nfs Apps" />
     </div>
     <div class="icon-card-label">Nfs Apps</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-performance-arrow.svg" alt="Performance Arrow" />
+      <img src="/brand-icons/f5-icon-cloud-performance-arrow.svg" alt="Performance Arrow" />
     </div>
     <div class="icon-card-label">Performance Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-phone-location.svg" alt="Phone Location" />
+      <img src="/brand-icons/f5-icon-cloud-phone-location.svg" alt="Phone Location" />
     </div>
     <div class="icon-card-label">Phone Location</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-private-public.svg" alt="Private Public" />
+      <img src="/brand-icons/f5-icon-cloud-private-public.svg" alt="Private Public" />
     </div>
     <div class="icon-card-label">Private Public</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-saas.svg" alt="Saas" />
+      <img src="/brand-icons/f5-icon-cloud-saas.svg" alt="Saas" />
     </div>
     <div class="icon-card-label">Saas</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-scale.svg" alt="Scale" />
+      <img src="/brand-icons/f5-icon-cloud-scale.svg" alt="Scale" />
     </div>
     <div class="icon-card-label">Scale</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-server-with-apps.svg" alt="Server With Apps" />
+      <img src="/brand-icons/f5-icon-cloud-server-with-apps.svg" alt="Server With Apps" />
     </div>
     <div class="icon-card-label">Server With Apps</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-servers.svg" alt="Servers" />
+      <img src="/brand-icons/f5-icon-cloud-servers.svg" alt="Servers" />
     </div>
     <div class="icon-card-label">Servers</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-servers-rotating-arrows.svg" alt="Servers Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-cloud-servers-rotating-arrows.svg" alt="Servers Rotating Arrows" />
     </div>
     <div class="icon-card-label">Servers Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-shield-arrow.svg" alt="Shield Arrow" />
+      <img src="/brand-icons/f5-icon-cloud-shield-arrow.svg" alt="Shield Arrow" />
     </div>
     <div class="icon-card-label">Shield Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-shield-checkmark.svg" alt="Shield Checkmark" />
+      <img src="/brand-icons/f5-icon-cloud-shield-checkmark.svg" alt="Shield Checkmark" />
     </div>
     <div class="icon-card-label">Shield Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-shield-checkmark-app.svg" alt="Shield Checkmark App" />
+      <img src="/brand-icons/f5-icon-cloud-shield-checkmark-app.svg" alt="Shield Checkmark App" />
     </div>
     <div class="icon-card-label">Shield Checkmark App</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-target.svg" alt="Target" />
+      <img src="/brand-icons/f5-icon-cloud-target.svg" alt="Target" />
     </div>
     <div class="icon-card-label">Target</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-tech-brain.svg" alt="Tech Brain" />
+      <img src="/brand-icons/f5-icon-cloud-tech-brain.svg" alt="Tech Brain" />
     </div>
     <div class="icon-card-label">Tech Brain</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-users.svg" alt="Users" />
+      <img src="/brand-icons/f5-icon-cloud-users.svg" alt="Users" />
     </div>
     <div class="icon-card-label">Users</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-virtual-app.svg" alt="Virtual App" />
+      <img src="/brand-icons/f5-icon-cloud-virtual-app.svg" alt="Virtual App" />
     </div>
     <div class="icon-card-label">Virtual App</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-with-cog.svg" alt="With Cog" />
+      <img src="/brand-icons/f5-icon-cloud-with-cog.svg" alt="With Cog" />
     </div>
     <div class="icon-card-label">With Cog</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-with-rotating-arrows.svg" alt="With Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-cloud-with-rotating-arrows.svg" alt="With Rotating Arrows" />
     </div>
     <div class="icon-card-label">With Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud-with-sun.svg" alt="With Sun" />
+      <img src="/brand-icons/f5-icon-cloud-with-sun.svg" alt="With Sun" />
     </div>
     <div class="icon-card-label">With Sun</div>
   </div>
@@ -840,277 +840,277 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-computer.svg" alt="Computer" />
+      <img src="/brand-icons/f5-icon-device-computer.svg" alt="Computer" />
     </div>
     <div class="icon-card-label">Computer</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-computer-chart.svg" alt="Computer Chart" />
+      <img src="/brand-icons/f5-icon-device-computer-chart.svg" alt="Computer Chart" />
     </div>
     <div class="icon-card-label">Computer Chart</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-computer-code.svg" alt="Computer Code" />
+      <img src="/brand-icons/f5-icon-device-computer-code.svg" alt="Computer Code" />
     </div>
     <div class="icon-card-label">Computer Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-computer-globe.svg" alt="Computer Globe" />
+      <img src="/brand-icons/f5-icon-device-computer-globe.svg" alt="Computer Globe" />
     </div>
     <div class="icon-card-label">Computer Globe</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-computer-no.svg" alt="Computer No" />
+      <img src="/brand-icons/f5-icon-device-computer-no.svg" alt="Computer No" />
     </div>
     <div class="icon-card-label">Computer No</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-computer-phone-with-checkmark.svg" alt="Computer Phone With Checkmark" />
+      <img src="/brand-icons/f5-icon-device-computer-phone-with-checkmark.svg" alt="Computer Phone With Checkmark" />
     </div>
     <div class="icon-card-label">Computer Phone With Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-computer-sad.svg" alt="Computer Sad" />
+      <img src="/brand-icons/f5-icon-device-computer-sad.svg" alt="Computer Sad" />
     </div>
     <div class="icon-card-label">Computer Sad</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-computer-shopping-cart.svg" alt="Computer Shopping Cart" />
+      <img src="/brand-icons/f5-icon-device-computer-shopping-cart.svg" alt="Computer Shopping Cart" />
     </div>
     <div class="icon-card-label">Computer Shopping Cart</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-computer-wifi.svg" alt="Computer Wifi" />
+      <img src="/brand-icons/f5-icon-device-computer-wifi.svg" alt="Computer Wifi" />
     </div>
     <div class="icon-card-label">Computer Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-computer-yes-phone-no.svg" alt="Computer Yes Phone No" />
+      <img src="/brand-icons/f5-icon-device-computer-yes-phone-no.svg" alt="Computer Yes Phone No" />
     </div>
     <div class="icon-card-label">Computer Yes Phone No</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-gaming-controller.svg" alt="Gaming Controller" />
+      <img src="/brand-icons/f5-icon-device-gaming-controller.svg" alt="Gaming Controller" />
     </div>
     <div class="icon-card-label">Gaming Controller</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop.svg" alt="Laptop" />
+      <img src="/brand-icons/f5-icon-device-laptop.svg" alt="Laptop" />
     </div>
     <div class="icon-card-label">Laptop</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-chart.svg" alt="Laptop Chart" />
+      <img src="/brand-icons/f5-icon-device-laptop-chart.svg" alt="Laptop Chart" />
     </div>
     <div class="icon-card-label">Laptop Chart</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-chart-warning-sign.svg" alt="Laptop Chart Warning Sign" />
+      <img src="/brand-icons/f5-icon-device-laptop-chart-warning-sign.svg" alt="Laptop Chart Warning Sign" />
     </div>
     <div class="icon-card-label">Laptop Chart Warning Sign</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-code.svg" alt="Laptop Code" />
+      <img src="/brand-icons/f5-icon-device-laptop-code.svg" alt="Laptop Code" />
     </div>
     <div class="icon-card-label">Laptop Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-gear-arrows.svg" alt="Laptop Gear Arrows" />
+      <img src="/brand-icons/f5-icon-device-laptop-gear-arrows.svg" alt="Laptop Gear Arrows" />
     </div>
     <div class="icon-card-label">Laptop Gear Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-globe.svg" alt="Laptop Globe" />
+      <img src="/brand-icons/f5-icon-device-laptop-globe.svg" alt="Laptop Globe" />
     </div>
     <div class="icon-card-label">Laptop Globe</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-lock-arrows.svg" alt="Laptop Lock Arrows" />
+      <img src="/brand-icons/f5-icon-device-laptop-lock-arrows.svg" alt="Laptop Lock Arrows" />
     </div>
     <div class="icon-card-label">Laptop Lock Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-no.svg" alt="Laptop No" />
+      <img src="/brand-icons/f5-icon-device-laptop-no.svg" alt="Laptop No" />
     </div>
     <div class="icon-card-label">Laptop No</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-sad.svg" alt="Laptop Sad" />
+      <img src="/brand-icons/f5-icon-device-laptop-sad.svg" alt="Laptop Sad" />
     </div>
     <div class="icon-card-label">Laptop Sad</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-shopping-cart.svg" alt="Laptop Shopping Cart" />
+      <img src="/brand-icons/f5-icon-device-laptop-shopping-cart.svg" alt="Laptop Shopping Cart" />
     </div>
     <div class="icon-card-label">Laptop Shopping Cart</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-skull-arrows.svg" alt="Laptop Skull Arrows" />
+      <img src="/brand-icons/f5-icon-device-laptop-skull-arrows.svg" alt="Laptop Skull Arrows" />
     </div>
     <div class="icon-card-label">Laptop Skull Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-spike-warning.svg" alt="Laptop Spike Warning" />
+      <img src="/brand-icons/f5-icon-device-laptop-spike-warning.svg" alt="Laptop Spike Warning" />
     </div>
     <div class="icon-card-label">Laptop Spike Warning</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-user-request.svg" alt="Laptop User Request" />
+      <img src="/brand-icons/f5-icon-device-laptop-user-request.svg" alt="Laptop User Request" />
     </div>
     <div class="icon-card-label">Laptop User Request</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-laptop-wifi.svg" alt="Laptop Wifi" />
+      <img src="/brand-icons/f5-icon-device-laptop-wifi.svg" alt="Laptop Wifi" />
     </div>
     <div class="icon-card-label">Laptop Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-phone.svg" alt="Phone" />
+      <img src="/brand-icons/f5-icon-device-phone.svg" alt="Phone" />
     </div>
     <div class="icon-card-label">Phone</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-phone-code.svg" alt="Phone Code" />
+      <img src="/brand-icons/f5-icon-device-phone-code.svg" alt="Phone Code" />
     </div>
     <div class="icon-card-label">Phone Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-phone-health.svg" alt="Phone Health" />
+      <img src="/brand-icons/f5-icon-device-phone-health.svg" alt="Phone Health" />
     </div>
     <div class="icon-card-label">Phone Health</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-phone-lock.svg" alt="Phone Lock" />
+      <img src="/brand-icons/f5-icon-device-phone-lock.svg" alt="Phone Lock" />
     </div>
     <div class="icon-card-label">Phone Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-phone-no.svg" alt="Phone No" />
+      <img src="/brand-icons/f5-icon-device-phone-no.svg" alt="Phone No" />
     </div>
     <div class="icon-card-label">Phone No</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-phone-shield.svg" alt="Phone Shield" />
+      <img src="/brand-icons/f5-icon-device-phone-shield.svg" alt="Phone Shield" />
     </div>
     <div class="icon-card-label">Phone Shield</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-phone-text.svg" alt="Phone Text" />
+      <img src="/brand-icons/f5-icon-device-phone-text.svg" alt="Phone Text" />
     </div>
     <div class="icon-card-label">Phone Text</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-phone-tools.svg" alt="Phone Tools" />
+      <img src="/brand-icons/f5-icon-device-phone-tools.svg" alt="Phone Tools" />
     </div>
     <div class="icon-card-label">Phone Tools</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-phone-wifi.svg" alt="Phone Wifi" />
+      <img src="/brand-icons/f5-icon-device-phone-wifi.svg" alt="Phone Wifi" />
     </div>
     <div class="icon-card-label">Phone Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-tablet.svg" alt="Tablet" />
+      <img src="/brand-icons/f5-icon-device-tablet.svg" alt="Tablet" />
     </div>
     <div class="icon-card-label">Tablet</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-tablet-code.svg" alt="Tablet Code" />
+      <img src="/brand-icons/f5-icon-device-tablet-code.svg" alt="Tablet Code" />
     </div>
     <div class="icon-card-label">Tablet Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-tablet-ebook.svg" alt="Tablet Ebook" />
+      <img src="/brand-icons/f5-icon-device-tablet-ebook.svg" alt="Tablet Ebook" />
     </div>
     <div class="icon-card-label">Tablet Ebook</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-tablet-no.svg" alt="Tablet No" />
+      <img src="/brand-icons/f5-icon-device-tablet-no.svg" alt="Tablet No" />
     </div>
     <div class="icon-card-label">Tablet No</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-tablet-ribbon.svg" alt="Tablet Ribbon" />
+      <img src="/brand-icons/f5-icon-device-tablet-ribbon.svg" alt="Tablet Ribbon" />
     </div>
     <div class="icon-card-label">Tablet Ribbon</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-tablet-wifi.svg" alt="Tablet Wifi" />
+      <img src="/brand-icons/f5-icon-device-tablet-wifi.svg" alt="Tablet Wifi" />
     </div>
     <div class="icon-card-label">Tablet Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-vr-goggles.svg" alt="Vr Goggles" />
+      <img src="/brand-icons/f5-icon-device-vr-goggles.svg" alt="Vr Goggles" />
     </div>
     <div class="icon-card-label">Vr Goggles</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-washing-machine-wifi.svg" alt="Washing Machine Wifi" />
+      <img src="/brand-icons/f5-icon-device-washing-machine-wifi.svg" alt="Washing Machine Wifi" />
     </div>
     <div class="icon-card-label">Washing Machine Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-watch.svg" alt="Watch" />
+      <img src="/brand-icons/f5-icon-device-watch.svg" alt="Watch" />
     </div>
     <div class="icon-card-label">Watch</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-watch-notify-money.svg" alt="Watch Notify Money" />
+      <img src="/brand-icons/f5-icon-device-watch-notify-money.svg" alt="Watch Notify Money" />
     </div>
     <div class="icon-card-label">Watch Notify Money</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-watch-text.svg" alt="Watch Text" />
+      <img src="/brand-icons/f5-icon-device-watch-text.svg" alt="Watch Text" />
     </div>
     <div class="icon-card-label">Watch Text</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-device-watch-wifi.svg" alt="Watch Wifi" />
+      <img src="/brand-icons/f5-icon-device-watch-wifi.svg" alt="Watch Wifi" />
     </div>
     <div class="icon-card-label">Watch Wifi</div>
   </div>
@@ -1122,145 +1122,145 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-app-server.svg" alt="App Server" />
+      <img src="/brand-icons/f5-icon-hw-app-server.svg" alt="App Server" />
     </div>
     <div class="icon-card-label">App Server</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-big-ip.svg" alt="Big Ip" />
+      <img src="/brand-icons/f5-icon-hw-big-ip.svg" alt="Big Ip" />
     </div>
     <div class="icon-card-label">Big Ip</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-blade-server.svg" alt="Blade Server" />
+      <img src="/brand-icons/f5-icon-hw-blade-server.svg" alt="Blade Server" />
     </div>
     <div class="icon-card-label">Blade Server</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-database.svg" alt="Database" />
+      <img src="/brand-icons/f5-icon-hw-database.svg" alt="Database" />
     </div>
     <div class="icon-card-label">Database</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-database-shield.svg" alt="Database Shield" />
+      <img src="/brand-icons/f5-icon-hw-database-shield.svg" alt="Database Shield" />
     </div>
     <div class="icon-card-label">Database Shield</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-database-unlocked.svg" alt="Database Unlocked" />
+      <img src="/brand-icons/f5-icon-hw-database-unlocked.svg" alt="Database Unlocked" />
     </div>
     <div class="icon-card-label">Database Unlocked</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-file-server.svg" alt="File Server" />
+      <img src="/brand-icons/f5-icon-hw-file-server.svg" alt="File Server" />
     </div>
     <div class="icon-card-label">File Server</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-lightweight-antennae-wifi.svg" alt="Lightweight Antennae Wifi" />
+      <img src="/brand-icons/f5-icon-hw-lightweight-antennae-wifi.svg" alt="Lightweight Antennae Wifi" />
     </div>
     <div class="icon-card-label">Lightweight Antennae Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server.svg" alt="Server" />
+      <img src="/brand-icons/f5-icon-hw-server.svg" alt="Server" />
     </div>
     <div class="icon-card-label">Server</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-kubernetes.svg" alt="Server Kubernetes" />
+      <img src="/brand-icons/f5-icon-hw-server-kubernetes.svg" alt="Server Kubernetes" />
     </div>
     <div class="icon-card-label">Server Kubernetes</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-locked.svg" alt="Server Locked" />
+      <img src="/brand-icons/f5-icon-hw-server-locked.svg" alt="Server Locked" />
     </div>
     <div class="icon-card-label">Server Locked</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-rack.svg" alt="Server Rack" />
+      <img src="/brand-icons/f5-icon-hw-server-rack.svg" alt="Server Rack" />
     </div>
     <div class="icon-card-label">Server Rack</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-rack-ai-data.svg" alt="Server Rack Ai Data" />
+      <img src="/brand-icons/f5-icon-hw-server-rack-ai-data.svg" alt="Server Rack Ai Data" />
     </div>
     <div class="icon-card-label">Server Rack Ai Data</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-rack-ai-gear-data.svg" alt="Server Rack Ai Gear Data" />
+      <img src="/brand-icons/f5-icon-hw-server-rack-ai-gear-data.svg" alt="Server Rack Ai Gear Data" />
     </div>
     <div class="icon-card-label">Server Rack Ai Gear Data</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-rack-lock.svg" alt="Server Rack Lock" />
+      <img src="/brand-icons/f5-icon-hw-server-rack-lock.svg" alt="Server Rack Lock" />
     </div>
     <div class="icon-card-label">Server Rack Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-stack.svg" alt="Server Stack" />
+      <img src="/brand-icons/f5-icon-hw-server-stack.svg" alt="Server Stack" />
     </div>
     <div class="icon-card-label">Server Stack</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-stack-magnifying.svg" alt="Server Stack Magnifying" />
+      <img src="/brand-icons/f5-icon-hw-server-stack-magnifying.svg" alt="Server Stack Magnifying" />
     </div>
     <div class="icon-card-label">Server Stack Magnifying</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-stack-phone-arrows.svg" alt="Server Stack Phone Arrows" />
+      <img src="/brand-icons/f5-icon-hw-server-stack-phone-arrows.svg" alt="Server Stack Phone Arrows" />
     </div>
     <div class="icon-card-label">Server Stack Phone Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-stack-with-arrows.svg" alt="Server Stack With Arrows" />
+      <img src="/brand-icons/f5-icon-hw-server-stack-with-arrows.svg" alt="Server Stack With Arrows" />
     </div>
     <div class="icon-card-label">Server Stack With Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-server-unlocked.svg" alt="Server Unlocked" />
+      <img src="/brand-icons/f5-icon-hw-server-unlocked.svg" alt="Server Unlocked" />
     </div>
     <div class="icon-card-label">Server Unlocked</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-sim-swap.svg" alt="Sim Swap" />
+      <img src="/brand-icons/f5-icon-hw-sim-swap.svg" alt="Sim Swap" />
     </div>
     <div class="icon-card-label">Sim Swap</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-velos.svg" alt="Velos" />
+      <img src="/brand-icons/f5-icon-hw-velos.svg" alt="Velos" />
     </div>
     <div class="icon-card-label">Velos</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-viprion.svg" alt="Viprion" />
+      <img src="/brand-icons/f5-icon-hw-viprion.svg" alt="Viprion" />
     </div>
     <div class="icon-card-label">Viprion</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-hw-web-server.svg" alt="Web Server" />
+      <img src="/brand-icons/f5-icon-hw-web-server.svg" alt="Web Server" />
     </div>
     <div class="icon-card-label">Web Server</div>
   </div>
@@ -1272,793 +1272,793 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-4-diamonds.svg" alt="4 Diamonds" />
+      <img src="/brand-icons/f5-icon-network-4-diamonds.svg" alt="4 Diamonds" />
     </div>
     <div class="icon-card-label">4 Diamonds</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-4g-5g-circles.svg" alt="4G 5G Circles" />
+      <img src="/brand-icons/f5-icon-network-4g-5g-circles.svg" alt="4G 5G Circles" />
     </div>
     <div class="icon-card-label">4G 5G Circles</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-adc.svg" alt="Adc" />
+      <img src="/brand-icons/f5-icon-network-adc.svg" alt="Adc" />
     </div>
     <div class="icon-card-label">Adc</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-adc-rotating-arrows.svg" alt="Adc Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-network-adc-rotating-arrows.svg" alt="Adc Rotating Arrows" />
     </div>
     <div class="icon-card-label">Adc Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-agile.svg" alt="Agile" />
+      <img src="/brand-icons/f5-icon-network-agile.svg" alt="Agile" />
     </div>
     <div class="icon-card-label">Agile</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-api.svg" alt="Api" />
+      <img src="/brand-icons/f5-icon-network-api.svg" alt="Api" />
     </div>
     <div class="icon-card-label">Api</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-network-api-crawling.svg" alt="Api Crawling" />
+      <img src="/brand-icons/f5-network-api-crawling.svg" alt="Api Crawling" />
     </div>
     <div class="icon-card-label">Api Crawling</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-api-gateway.svg" alt="Api Gateway" />
+      <img src="/brand-icons/f5-icon-network-api-gateway.svg" alt="Api Gateway" />
     </div>
     <div class="icon-card-label">Api Gateway</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-network-api-inventory.svg" alt="Api Inventory" />
+      <img src="/brand-icons/f5-network-api-inventory.svg" alt="Api Inventory" />
     </div>
     <div class="icon-card-label">Api Inventory</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-network-api-testing.svg" alt="Api Testing" />
+      <img src="/brand-icons/f5-network-api-testing.svg" alt="Api Testing" />
     </div>
     <div class="icon-card-label">Api Testing</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-network-api-vulnerable.svg" alt="Api Vulnerable" />
+      <img src="/brand-icons/f5-network-api-vulnerable.svg" alt="Api Vulnerable" />
     </div>
     <div class="icon-card-label">Api Vulnerable</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-arrows.svg" alt="Arrows" />
+      <img src="/brand-icons/f5-icon-network-arrows.svg" alt="Arrows" />
     </div>
     <div class="icon-card-label">Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-arrows-left-right.svg" alt="Arrows Left Right" />
+      <img src="/brand-icons/f5-icon-network-arrows-left-right.svg" alt="Arrows Left Right" />
     </div>
     <div class="icon-card-label">Arrows Left Right</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-arrows-rotating.svg" alt="Arrows Rotating" />
+      <img src="/brand-icons/f5-icon-network-arrows-rotating.svg" alt="Arrows Rotating" />
     </div>
     <div class="icon-card-label">Arrows Rotating</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-arrows-transfer-dashed-circle.svg" alt="Arrows Transfer Dashed Circle" />
+      <img src="/brand-icons/f5-icon-network-arrows-transfer-dashed-circle.svg" alt="Arrows Transfer Dashed Circle" />
     </div>
     <div class="icon-card-label">Arrows Transfer Dashed Circle</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-automated-network.svg" alt="Automated Network" />
+      <img src="/brand-icons/f5-icon-network-automated-network.svg" alt="Automated Network" />
     </div>
     <div class="icon-card-label">Automated Network</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-automation.svg" alt="Automation" />
+      <img src="/brand-icons/f5-icon-network-automation.svg" alt="Automation" />
     </div>
     <div class="icon-card-label">Automation</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-automation1.svg" alt="Automation1" />
+      <img src="/brand-icons/f5-icon-network-automation1.svg" alt="Automation1" />
     </div>
     <div class="icon-card-label">Automation1</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-ball-of-fire.svg" alt="Ball Of Fire" />
+      <img src="/brand-icons/f5-icon-network-ball-of-fire.svg" alt="Ball Of Fire" />
     </div>
     <div class="icon-card-label">Ball Of Fire</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-big-ip-next-spk.svg" alt="Big Ip Next Spk" />
+      <img src="/brand-icons/f5-icon-network-big-ip-next-spk.svg" alt="Big Ip Next Spk" />
     </div>
     <div class="icon-card-label">Big Ip Next Spk</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-big-ip-tmos.svg" alt="Big Ip Tmos" />
+      <img src="/brand-icons/f5-icon-network-big-ip-tmos.svg" alt="Big Ip Tmos" />
     </div>
     <div class="icon-card-label">Big Ip Tmos</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-big-iq.svg" alt="Big Iq" />
+      <img src="/brand-icons/f5-icon-network-big-iq.svg" alt="Big Iq" />
     </div>
     <div class="icon-card-label">Big Iq</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-binary.svg" alt="Binary" />
+      <img src="/brand-icons/f5-icon-network-binary.svg" alt="Binary" />
     </div>
     <div class="icon-card-label">Binary</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-blocks-rotating-arrows.svg" alt="Blocks Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-network-blocks-rotating-arrows.svg" alt="Blocks Rotating Arrows" />
     </div>
     <div class="icon-card-label">Blocks Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-chip.svg" alt="Chip" />
+      <img src="/brand-icons/f5-icon-network-chip.svg" alt="Chip" />
     </div>
     <div class="icon-card-label">Chip</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-chip-ai.svg" alt="Chip Ai" />
+      <img src="/brand-icons/f5-icon-network-chip-ai.svg" alt="Chip Ai" />
     </div>
     <div class="icon-card-label">Chip Ai</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-chip-code.svg" alt="Chip Code" />
+      <img src="/brand-icons/f5-icon-network-chip-code.svg" alt="Chip Code" />
     </div>
     <div class="icon-card-label">Chip Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-chip-ml.svg" alt="Chip Ml" />
+      <img src="/brand-icons/f5-icon-network-chip-ml.svg" alt="Chip Ml" />
     </div>
     <div class="icon-card-label">Chip Ml</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-circle-3-arrows.svg" alt="Circle 3 Arrows" />
+      <img src="/brand-icons/f5-icon-network-circle-3-arrows.svg" alt="Circle 3 Arrows" />
     </div>
     <div class="icon-card-label">Circle 3 Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-clock-automation.svg" alt="Clock Automation" />
+      <img src="/brand-icons/f5-icon-network-clock-automation.svg" alt="Clock Automation" />
     </div>
     <div class="icon-card-label">Clock Automation</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-code-key.svg" alt="Code Key" />
+      <img src="/brand-icons/f5-icon-network-code-key.svg" alt="Code Key" />
     </div>
     <div class="icon-card-label">Code Key</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-code-security.svg" alt="Code Security" />
+      <img src="/brand-icons/f5-icon-network-code-security.svg" alt="Code Security" />
     </div>
     <div class="icon-card-label">Code Security</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-complexity.svg" alt="Complexity" />
+      <img src="/brand-icons/f5-icon-network-complexity.svg" alt="Complexity" />
     </div>
     <div class="icon-card-label">Complexity</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-connected-circles.svg" alt="Connected Circles" />
+      <img src="/brand-icons/f5-icon-network-connected-circles.svg" alt="Connected Circles" />
     </div>
     <div class="icon-card-label">Connected Circles</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-consolidation.svg" alt="Consolidation" />
+      <img src="/brand-icons/f5-icon-network-consolidation.svg" alt="Consolidation" />
     </div>
     <div class="icon-card-label">Consolidation</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-container-connector-1.svg" alt="Container Connector 1" />
+      <img src="/brand-icons/f5-icon-network-container-connector-1.svg" alt="Container Connector 1" />
     </div>
     <div class="icon-card-label">Container Connector 1</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-container-connector-2.svg" alt="Container Connector 2" />
+      <img src="/brand-icons/f5-icon-network-container-connector-2.svg" alt="Container Connector 2" />
     </div>
     <div class="icon-card-label">Container Connector 2</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-container-connector-3.svg" alt="Container Connector 3" />
+      <img src="/brand-icons/f5-icon-network-container-connector-3.svg" alt="Container Connector 3" />
     </div>
     <div class="icon-card-label">Container Connector 3</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-container-virtualization.svg" alt="Container Virtualization" />
+      <img src="/brand-icons/f5-icon-network-container-virtualization.svg" alt="Container Virtualization" />
     </div>
     <div class="icon-card-label">Container Virtualization</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-containers.svg" alt="Containers" />
+      <img src="/brand-icons/f5-icon-network-containers.svg" alt="Containers" />
     </div>
     <div class="icon-card-label">Containers</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-control-plane.svg" alt="Control Plane" />
+      <img src="/brand-icons/f5-icon-network-control-plane.svg" alt="Control Plane" />
     </div>
     <div class="icon-card-label">Control Plane</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-cross-data.svg" alt="Cross Data" />
+      <img src="/brand-icons/f5-icon-network-cross-data.svg" alt="Cross Data" />
     </div>
     <div class="icon-card-label">Cross Data</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-cross-data-circle.svg" alt="Cross Data Circle" />
+      <img src="/brand-icons/f5-icon-network-cross-data-circle.svg" alt="Cross Data Circle" />
     </div>
     <div class="icon-card-label">Cross Data Circle</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-cross-data-left.svg" alt="Cross Data Left" />
+      <img src="/brand-icons/f5-icon-network-cross-data-left.svg" alt="Cross Data Left" />
     </div>
     <div class="icon-card-label">Cross Data Left</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-cross-data-lock.svg" alt="Cross Data Lock" />
+      <img src="/brand-icons/f5-icon-network-cross-data-lock.svg" alt="Cross Data Lock" />
     </div>
     <div class="icon-card-label">Cross Data Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-data-aggregator.svg" alt="Data Aggregator" />
+      <img src="/brand-icons/f5-icon-network-data-aggregator.svg" alt="Data Aggregator" />
     </div>
     <div class="icon-card-label">Data Aggregator</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-data-automation.svg" alt="Data Automation" />
+      <img src="/brand-icons/f5-icon-network-data-automation.svg" alt="Data Automation" />
     </div>
     <div class="icon-card-label">Data Automation</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-data-edge-rotating-arrows.svg" alt="Data Edge Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-network-data-edge-rotating-arrows.svg" alt="Data Edge Rotating Arrows" />
     </div>
     <div class="icon-card-label">Data Edge Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-network-data-fabric.svg" alt="Data Fabric" />
+      <img src="/brand-icons/f5-network-data-fabric.svg" alt="Data Fabric" />
     </div>
     <div class="icon-card-label">Data Fabric</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-ddos-protection.svg" alt="Ddos Protection" />
+      <img src="/brand-icons/f5-icon-network-ddos-protection.svg" alt="Ddos Protection" />
     </div>
     <div class="icon-card-label">Ddos Protection</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-deployment.svg" alt="Deployment" />
+      <img src="/brand-icons/f5-icon-network-deployment.svg" alt="Deployment" />
     </div>
     <div class="icon-card-label">Deployment</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-dns-1.svg" alt="Dns 1" />
+      <img src="/brand-icons/f5-icon-network-dns-1.svg" alt="Dns 1" />
     </div>
     <div class="icon-card-label">Dns 1</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-dns-2.svg" alt="Dns 2" />
+      <img src="/brand-icons/f5-icon-network-dns-2.svg" alt="Dns 2" />
     </div>
     <div class="icon-card-label">Dns 2</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-dns-3-arrows.svg" alt="Dns 3 Arrows" />
+      <img src="/brand-icons/f5-icon-network-dns-3-arrows.svg" alt="Dns 3 Arrows" />
     </div>
     <div class="icon-card-label">Dns 3 Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-dns-load-balance.svg" alt="Dns Load Balance" />
+      <img src="/brand-icons/f5-icon-network-dns-load-balance.svg" alt="Dns Load Balance" />
     </div>
     <div class="icon-card-label">Dns Load Balance</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-file-css.svg" alt="File Css" />
+      <img src="/brand-icons/f5-icon-network-file-css.svg" alt="File Css" />
     </div>
     <div class="icon-card-label">File Css</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-file-html.svg" alt="File Html" />
+      <img src="/brand-icons/f5-icon-network-file-html.svg" alt="File Html" />
     </div>
     <div class="icon-card-label">File Html</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-file-http.svg" alt="File Http" />
+      <img src="/brand-icons/f5-icon-network-file-http.svg" alt="File Http" />
     </div>
     <div class="icon-card-label">File Http</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-fine-grained-limited-access.svg" alt="Fine Grained Limited Access" />
+      <img src="/brand-icons/f5-icon-network-fine-grained-limited-access.svg" alt="Fine Grained Limited Access" />
     </div>
     <div class="icon-card-label">Fine Grained Limited Access</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-framework.svg" alt="Framework" />
+      <img src="/brand-icons/f5-icon-network-framework.svg" alt="Framework" />
     </div>
     <div class="icon-card-label">Framework</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-framework-rotating-arrows.svg" alt="Framework Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-network-framework-rotating-arrows.svg" alt="Framework Rotating Arrows" />
     </div>
     <div class="icon-card-label">Framework Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-funnel.svg" alt="Funnel" />
+      <img src="/brand-icons/f5-icon-network-funnel.svg" alt="Funnel" />
     </div>
     <div class="icon-card-label">Funnel</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gateway.svg" alt="Gateway" />
+      <img src="/brand-icons/f5-icon-network-gateway.svg" alt="Gateway" />
     </div>
     <div class="icon-card-label">Gateway</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear.svg" alt="Gear" />
+      <img src="/brand-icons/f5-icon-network-gear.svg" alt="Gear" />
     </div>
     <div class="icon-card-label">Gear</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-bot.svg" alt="Gear Bot" />
+      <img src="/brand-icons/f5-icon-network-gear-bot.svg" alt="Gear Bot" />
     </div>
     <div class="icon-card-label">Gear Bot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-code.svg" alt="Gear Code" />
+      <img src="/brand-icons/f5-icon-network-gear-code.svg" alt="Gear Code" />
     </div>
     <div class="icon-card-label">Gear Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-globe.svg" alt="Gear Globe" />
+      <img src="/brand-icons/f5-icon-network-gear-globe.svg" alt="Gear Globe" />
     </div>
     <div class="icon-card-label">Gear Globe</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-graph.svg" alt="Gear Graph" />
+      <img src="/brand-icons/f5-icon-network-gear-graph.svg" alt="Gear Graph" />
     </div>
     <div class="icon-card-label">Gear Graph</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-graph-app-ai-ops.svg" alt="Gear Graph App Ai Ops" />
+      <img src="/brand-icons/f5-icon-network-gear-graph-app-ai-ops.svg" alt="Gear Graph App Ai Ops" />
     </div>
     <div class="icon-card-label">Gear Graph App Ai Ops</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-graph-lightbulb-ai.svg" alt="Gear Graph Lightbulb Ai" />
+      <img src="/brand-icons/f5-icon-network-gear-graph-lightbulb-ai.svg" alt="Gear Graph Lightbulb Ai" />
     </div>
     <div class="icon-card-label">Gear Graph Lightbulb Ai</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-graph-machine-learning.svg" alt="Gear Graph Machine Learning" />
+      <img src="/brand-icons/f5-icon-network-gear-graph-machine-learning.svg" alt="Gear Graph Machine Learning" />
     </div>
     <div class="icon-card-label">Gear Graph Machine Learning</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-hourglass.svg" alt="Gear Hourglass" />
+      <img src="/brand-icons/f5-icon-network-gear-hourglass.svg" alt="Gear Hourglass" />
     </div>
     <div class="icon-card-label">Gear Hourglass</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-infinity.svg" alt="Gear Infinity" />
+      <img src="/brand-icons/f5-icon-network-gear-infinity.svg" alt="Gear Infinity" />
     </div>
     <div class="icon-card-label">Gear Infinity</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-lock.svg" alt="Gear Lock" />
+      <img src="/brand-icons/f5-icon-network-gear-lock.svg" alt="Gear Lock" />
     </div>
     <div class="icon-card-label">Gear Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-monitor.svg" alt="Gear Monitor" />
+      <img src="/brand-icons/f5-icon-network-gear-monitor.svg" alt="Gear Monitor" />
     </div>
     <div class="icon-card-label">Gear Monitor</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-warning.svg" alt="Gear Warning" />
+      <img src="/brand-icons/f5-icon-network-gear-warning.svg" alt="Gear Warning" />
     </div>
     <div class="icon-card-label">Gear Warning</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gear-workflow.svg" alt="Gear Workflow" />
+      <img src="/brand-icons/f5-icon-network-gear-workflow.svg" alt="Gear Workflow" />
     </div>
     <div class="icon-card-label">Gear Workflow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-gears-arrows.svg" alt="Gears Arrows" />
+      <img src="/brand-icons/f5-icon-network-gears-arrows.svg" alt="Gears Arrows" />
     </div>
     <div class="icon-card-label">Gears Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-globe.svg" alt="Globe" />
+      <img src="/brand-icons/f5-icon-network-globe.svg" alt="Globe" />
     </div>
     <div class="icon-card-label">Globe</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-globe-edge-rotating-arrows.svg" alt="Globe Edge Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-network-globe-edge-rotating-arrows.svg" alt="Globe Edge Rotating Arrows" />
     </div>
     <div class="icon-card-label">Globe Edge Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-globe-load-balance.svg" alt="Globe Load Balance" />
+      <img src="/brand-icons/f5-icon-network-globe-load-balance.svg" alt="Globe Load Balance" />
     </div>
     <div class="icon-card-label">Globe Load Balance</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-globe-mouse-arrow.svg" alt="Globe Mouse Arrow" />
+      <img src="/brand-icons/f5-icon-network-globe-mouse-arrow.svg" alt="Globe Mouse Arrow" />
     </div>
     <div class="icon-card-label">Globe Mouse Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-globe-rotating-arrows.svg" alt="Globe Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-network-globe-rotating-arrows.svg" alt="Globe Rotating Arrows" />
     </div>
     <div class="icon-card-label">Globe Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-high-performance.svg" alt="High Performance" />
+      <img src="/brand-icons/f5-icon-network-high-performance.svg" alt="High Performance" />
     </div>
     <div class="icon-card-label">High Performance</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-iapp.svg" alt="Iapp" />
+      <img src="/brand-icons/f5-icon-network-iapp.svg" alt="Iapp" />
     </div>
     <div class="icon-card-label">Iapp</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-infrastructure.svg" alt="Infrastructure" />
+      <img src="/brand-icons/f5-icon-network-infrastructure.svg" alt="Infrastructure" />
     </div>
     <div class="icon-card-label">Infrastructure</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-ingress-controller-generic.svg" alt="Ingress Controller Generic" />
+      <img src="/brand-icons/f5-icon-network-ingress-controller-generic.svg" alt="Ingress Controller Generic" />
     </div>
     <div class="icon-card-label">Ingress Controller Generic</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-instance-replication.svg" alt="Instance Replication" />
+      <img src="/brand-icons/f5-icon-network-instance-replication.svg" alt="Instance Replication" />
     </div>
     <div class="icon-card-label">Instance Replication</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-internet-globe.svg" alt="Internet Globe" />
+      <img src="/brand-icons/f5-icon-network-internet-globe.svg" alt="Internet Globe" />
     </div>
     <div class="icon-card-label">Internet Globe</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-iot.svg" alt="Iot" />
+      <img src="/brand-icons/f5-icon-network-iot.svg" alt="Iot" />
     </div>
     <div class="icon-card-label">Iot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-ipv4-ipv6.svg" alt="Ipv4 Ipv6" />
+      <img src="/brand-icons/f5-icon-network-ipv4-ipv6.svg" alt="Ipv4 Ipv6" />
     </div>
     <div class="icon-card-label">Ipv4 Ipv6</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-irules.svg" alt="Irules" />
+      <img src="/brand-icons/f5-icon-network-irules.svg" alt="Irules" />
     </div>
     <div class="icon-card-label">Irules</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-link.svg" alt="Link" />
+      <img src="/brand-icons/f5-icon-network-link.svg" alt="Link" />
     </div>
     <div class="icon-card-label">Link</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-lock.svg" alt="Lock" />
+      <img src="/brand-icons/f5-icon-network-lock.svg" alt="Lock" />
     </div>
     <div class="icon-card-label">Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-low-performance.svg" alt="Low Performance" />
+      <img src="/brand-icons/f5-icon-network-low-performance.svg" alt="Low Performance" />
     </div>
     <div class="icon-card-label">Low Performance</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-microservices.svg" alt="Microservices" />
+      <img src="/brand-icons/f5-icon-network-microservices.svg" alt="Microservices" />
     </div>
     <div class="icon-card-label">Microservices</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-microservices-alt.svg" alt="Microservices Alt" />
+      <img src="/brand-icons/f5-icon-network-microservices-alt.svg" alt="Microservices Alt" />
     </div>
     <div class="icon-card-label">Microservices Alt</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-modern-architecture.svg" alt="Modern Architecture" />
+      <img src="/brand-icons/f5-icon-network-modern-architecture.svg" alt="Modern Architecture" />
     </div>
     <div class="icon-card-label">Modern Architecture</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-monoliths.svg" alt="Monoliths" />
+      <img src="/brand-icons/f5-icon-network-monoliths.svg" alt="Monoliths" />
     </div>
     <div class="icon-card-label">Monoliths</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-networking-operations.svg" alt="Networking Operations" />
+      <img src="/brand-icons/f5-icon-network-networking-operations.svg" alt="Networking Operations" />
     </div>
     <div class="icon-card-label">Networking Operations</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-nginx.svg" alt="Nginx" />
+      <img src="/brand-icons/f5-icon-network-nginx.svg" alt="Nginx" />
     </div>
     <div class="icon-card-label">Nginx</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-optimization.svg" alt="Optimization" />
+      <img src="/brand-icons/f5-icon-network-optimization.svg" alt="Optimization" />
     </div>
     <div class="icon-card-label">Optimization</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-orchestrator.svg" alt="Orchestrator" />
+      <img src="/brand-icons/f5-icon-network-orchestrator.svg" alt="Orchestrator" />
     </div>
     <div class="icon-card-label">Orchestrator</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-performance-automation.svg" alt="Performance Automation" />
+      <img src="/brand-icons/f5-icon-network-performance-automation.svg" alt="Performance Automation" />
     </div>
     <div class="icon-card-label">Performance Automation</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-performance-high-warning.svg" alt="Performance High Warning" />
+      <img src="/brand-icons/f5-icon-network-performance-high-warning.svg" alt="Performance High Warning" />
     </div>
     <div class="icon-card-label">Performance High Warning</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-performance-low-warning.svg" alt="Performance Low Warning" />
+      <img src="/brand-icons/f5-icon-network-performance-low-warning.svg" alt="Performance Low Warning" />
     </div>
     <div class="icon-card-label">Performance Low Warning</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-php.svg" alt="Php" />
+      <img src="/brand-icons/f5-icon-network-php.svg" alt="Php" />
     </div>
     <div class="icon-card-label">Php</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-platform-agnostic.svg" alt="Platform Agnostic" />
+      <img src="/brand-icons/f5-icon-network-platform-agnostic.svg" alt="Platform Agnostic" />
     </div>
     <div class="icon-card-label">Platform Agnostic</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-provisioning.svg" alt="Provisioning" />
+      <img src="/brand-icons/f5-icon-network-provisioning.svg" alt="Provisioning" />
     </div>
     <div class="icon-card-label">Provisioning</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-ram-chip.svg" alt="Ram Chip" />
+      <img src="/brand-icons/f5-icon-network-ram-chip.svg" alt="Ram Chip" />
     </div>
     <div class="icon-card-label">Ram Chip</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-rest-api.svg" alt="Rest Api" />
+      <img src="/brand-icons/f5-icon-network-rest-api.svg" alt="Rest Api" />
     </div>
     <div class="icon-card-label">Rest Api</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-router.svg" alt="Router" />
+      <img src="/brand-icons/f5-icon-network-router.svg" alt="Router" />
     </div>
     <div class="icon-card-label">Router</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-scale-down.svg" alt="Scale Down" />
+      <img src="/brand-icons/f5-icon-network-scale-down.svg" alt="Scale Down" />
     </div>
     <div class="icon-card-label">Scale Down</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-scale-up.svg" alt="Scale Up" />
+      <img src="/brand-icons/f5-icon-network-scale-up.svg" alt="Scale Up" />
     </div>
     <div class="icon-card-label">Scale Up</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-network-shadow-api.svg" alt="Shadow Api" />
+      <img src="/brand-icons/f5-network-shadow-api.svg" alt="Shadow Api" />
     </div>
     <div class="icon-card-label">Shadow Api</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-signal.svg" alt="Signal" />
+      <img src="/brand-icons/f5-icon-network-signal.svg" alt="Signal" />
     </div>
     <div class="icon-card-label">Signal</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-simple-architecture.svg" alt="Simple Architecture" />
+      <img src="/brand-icons/f5-icon-network-simple-architecture.svg" alt="Simple Architecture" />
     </div>
     <div class="icon-card-label">Simple Architecture</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-simple-architecture-automation.svg" alt="Simple Architecture Automation" />
+      <img src="/brand-icons/f5-icon-network-simple-architecture-automation.svg" alt="Simple Architecture Automation" />
     </div>
     <div class="icon-card-label">Simple Architecture Automation</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-simple-architecture-circle.svg" alt="Simple Architecture Circle" />
+      <img src="/brand-icons/f5-icon-network-simple-architecture-circle.svg" alt="Simple Architecture Circle" />
     </div>
     <div class="icon-card-label">Simple Architecture Circle</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-sql.svg" alt="Sql" />
+      <img src="/brand-icons/f5-icon-network-sql.svg" alt="Sql" />
     </div>
     <div class="icon-card-label">Sql</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-squares-stack.svg" alt="Squares Stack" />
+      <img src="/brand-icons/f5-icon-network-squares-stack.svg" alt="Squares Stack" />
     </div>
     <div class="icon-card-label">Squares Stack</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-stack.svg" alt="Stack" />
+      <img src="/brand-icons/f5-icon-network-stack.svg" alt="Stack" />
     </div>
     <div class="icon-card-label">Stack</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-stack-app.svg" alt="Stack App" />
+      <img src="/brand-icons/f5-icon-network-stack-app.svg" alt="Stack App" />
     </div>
     <div class="icon-card-label">Stack App</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-stack-gear-code.svg" alt="Stack Gear Code" />
+      <img src="/brand-icons/f5-icon-network-stack-gear-code.svg" alt="Stack Gear Code" />
     </div>
     <div class="icon-card-label">Stack Gear Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-stack-kubernetes.svg" alt="Stack Kubernetes" />
+      <img src="/brand-icons/f5-icon-network-stack-kubernetes.svg" alt="Stack Kubernetes" />
     </div>
     <div class="icon-card-label">Stack Kubernetes</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-synthetic-monitoring.svg" alt="Synthetic Monitoring" />
+      <img src="/brand-icons/f5-icon-network-synthetic-monitoring.svg" alt="Synthetic Monitoring" />
     </div>
     <div class="icon-card-label">Synthetic Monitoring</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-tmos.svg" alt="Tmos" />
+      <img src="/brand-icons/f5-icon-network-tmos.svg" alt="Tmos" />
     </div>
     <div class="icon-card-label">Tmos</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-virtual.svg" alt="Virtual" />
+      <img src="/brand-icons/f5-icon-network-virtual.svg" alt="Virtual" />
     </div>
     <div class="icon-card-label">Virtual</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-vnf.svg" alt="Vnf" />
+      <img src="/brand-icons/f5-icon-network-vnf.svg" alt="Vnf" />
     </div>
     <div class="icon-card-label">Vnf</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-wifi.svg" alt="Wifi" />
+      <img src="/brand-icons/f5-icon-network-wifi.svg" alt="Wifi" />
     </div>
     <div class="icon-card-label">Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network-wifi-in-middle.svg" alt="Wifi In Middle" />
+      <img src="/brand-icons/f5-icon-network-wifi-in-middle.svg" alt="Wifi In Middle" />
     </div>
     <div class="icon-card-label">Wifi In Middle</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-network-zombi-api.svg" alt="Zombi Api" />
+      <img src="/brand-icons/f5-network-zombi-api.svg" alt="Zombi Api" />
     </div>
     <div class="icon-card-label">Zombi Api</div>
   </div>
@@ -2070,457 +2070,457 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-secutiry-api.svg" alt="Api" />
+      <img src="/brand-icons/f5-secutiry-api.svg" alt="Api" />
     </div>
     <div class="icon-card-label">Api</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-apps-arrow-lock.svg" alt="Apps Arrow Lock" />
+      <img src="/brand-icons/f5-icon-security-apps-arrow-lock.svg" alt="Apps Arrow Lock" />
     </div>
     <div class="icon-card-label">Apps Arrow Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-bad-chat-bot.svg" alt="Bad Chat Bot" />
+      <img src="/brand-icons/f5-icon-security-bad-chat-bot.svg" alt="Bad Chat Bot" />
     </div>
     <div class="icon-card-label">Bad Chat Bot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-biometrics.svg" alt="Biometrics" />
+      <img src="/brand-icons/f5-icon-security-biometrics.svg" alt="Biometrics" />
     </div>
     <div class="icon-card-label">Biometrics</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-bot.svg" alt="Bot" />
+      <img src="/brand-icons/f5-icon-security-bot.svg" alt="Bot" />
     </div>
     <div class="icon-card-label">Bot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-security-bot-defence.svg" alt="Bot Defence" />
+      <img src="/brand-icons/f5-security-bot-defence.svg" alt="Bot Defence" />
     </div>
     <div class="icon-card-label">Bot Defence</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-bot-happy.svg" alt="Bot Happy" />
+      <img src="/brand-icons/f5-icon-security-bot-happy.svg" alt="Bot Happy" />
     </div>
     <div class="icon-card-label">Bot Happy</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-bug.svg" alt="Bug" />
+      <img src="/brand-icons/f5-icon-security-bug.svg" alt="Bug" />
     </div>
     <div class="icon-card-label">Bug</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-code.svg" alt="Code" />
+      <img src="/brand-icons/f5-icon-security-code.svg" alt="Code" />
     </div>
     <div class="icon-card-label">Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-doc-credit-card-skull.svg" alt="Doc Credit Card Skull" />
+      <img src="/brand-icons/f5-icon-security-doc-credit-card-skull.svg" alt="Doc Credit Card Skull" />
     </div>
     <div class="icon-card-label">Doc Credit Card Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-doc-lock.svg" alt="Doc Lock" />
+      <img src="/brand-icons/f5-icon-security-doc-lock.svg" alt="Doc Lock" />
     </div>
     <div class="icon-card-label">Doc Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-doc-question-mark.svg" alt="Doc Question Mark" />
+      <img src="/brand-icons/f5-icon-security-doc-question-mark.svg" alt="Doc Question Mark" />
     </div>
     <div class="icon-card-label">Doc Question Mark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-doc-shield.svg" alt="Doc Shield" />
+      <img src="/brand-icons/f5-icon-security-doc-shield.svg" alt="Doc Shield" />
     </div>
     <div class="icon-card-label">Doc Shield</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-security-encrypted-traffic.svg" alt="Encrypted Traffic" />
+      <img src="/brand-icons/f5-security-encrypted-traffic.svg" alt="Encrypted Traffic" />
     </div>
     <div class="icon-card-label">Encrypted Traffic</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-envelope-skull.svg" alt="Envelope Skull" />
+      <img src="/brand-icons/f5-icon-security-envelope-skull.svg" alt="Envelope Skull" />
     </div>
     <div class="icon-card-label">Envelope Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-fingerprint.svg" alt="Fingerprint" />
+      <img src="/brand-icons/f5-icon-security-fingerprint.svg" alt="Fingerprint" />
     </div>
     <div class="icon-card-label">Fingerprint</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-fingerprint-rotating-arrows.svg" alt="Fingerprint Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-security-fingerprint-rotating-arrows.svg" alt="Fingerprint Rotating Arrows" />
     </div>
     <div class="icon-card-label">Fingerprint Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-firewall.svg" alt="Firewall" />
+      <img src="/brand-icons/f5-icon-security-firewall.svg" alt="Firewall" />
     </div>
     <div class="icon-card-label">Firewall</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-firewall-bot.svg" alt="Firewall Bot" />
+      <img src="/brand-icons/f5-icon-security-firewall-bot.svg" alt="Firewall Bot" />
     </div>
     <div class="icon-card-label">Firewall Bot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-firewall-checkmark.svg" alt="Firewall Checkmark" />
+      <img src="/brand-icons/f5-icon-security-firewall-checkmark.svg" alt="Firewall Checkmark" />
     </div>
     <div class="icon-card-label">Firewall Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-firewall-iot.svg" alt="Firewall Iot" />
+      <img src="/brand-icons/f5-icon-security-firewall-iot.svg" alt="Firewall Iot" />
     </div>
     <div class="icon-card-label">Firewall Iot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-firewall-shield.svg" alt="Firewall Shield" />
+      <img src="/brand-icons/f5-icon-security-firewall-shield.svg" alt="Firewall Shield" />
     </div>
     <div class="icon-card-label">Firewall Shield</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-gift-card-skull.svg" alt="Gift Card Skull" />
+      <img src="/brand-icons/f5-icon-security-gift-card-skull.svg" alt="Gift Card Skull" />
     </div>
     <div class="icon-card-label">Gift Card Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-good-chat-bot.svg" alt="Good Chat Bot" />
+      <img src="/brand-icons/f5-icon-security-good-chat-bot.svg" alt="Good Chat Bot" />
     </div>
     <div class="icon-card-label">Good Chat Bot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-hacker.svg" alt="Hacker" />
+      <img src="/brand-icons/f5-icon-security-hacker.svg" alt="Hacker" />
     </div>
     <div class="icon-card-label">Hacker</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-key-lock.svg" alt="Key Lock" />
+      <img src="/brand-icons/f5-icon-security-key-lock.svg" alt="Key Lock" />
     </div>
     <div class="icon-card-label">Key Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-key-skull.svg" alt="Key Skull" />
+      <img src="/brand-icons/f5-icon-security-key-skull.svg" alt="Key Skull" />
     </div>
     <div class="icon-card-label">Key Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-laptop-bot.svg" alt="Laptop Bot" />
+      <img src="/brand-icons/f5-icon-security-laptop-bot.svg" alt="Laptop Bot" />
     </div>
     <div class="icon-card-label">Laptop Bot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-lock.svg" alt="Lock" />
+      <img src="/brand-icons/f5-icon-security-lock.svg" alt="Lock" />
     </div>
     <div class="icon-card-label">Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-lock-cicles.svg" alt="Lock Cicles" />
+      <img src="/brand-icons/f5-icon-security-lock-cicles.svg" alt="Lock Cicles" />
     </div>
     <div class="icon-card-label">Lock Cicles</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-lock-circle.svg" alt="Lock Circle" />
+      <img src="/brand-icons/f5-icon-security-lock-circle.svg" alt="Lock Circle" />
     </div>
     <div class="icon-card-label">Lock Circle</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-lock-crossing-arrows.svg" alt="Lock Crossing Arrows" />
+      <img src="/brand-icons/f5-icon-security-lock-crossing-arrows.svg" alt="Lock Crossing Arrows" />
     </div>
     <div class="icon-card-label">Lock Crossing Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-lock-dials.svg" alt="Lock Dials" />
+      <img src="/brand-icons/f5-icon-security-lock-dials.svg" alt="Lock Dials" />
     </div>
     <div class="icon-card-label">Lock Dials</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-locks-with-arrows.svg" alt="Locks With Arrows" />
+      <img src="/brand-icons/f5-icon-security-locks-with-arrows.svg" alt="Locks With Arrows" />
     </div>
     <div class="icon-card-label">Locks With Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-login-password-lock.svg" alt="Login Password Lock" />
+      <img src="/brand-icons/f5-icon-security-login-password-lock.svg" alt="Login Password Lock" />
     </div>
     <div class="icon-card-label">Login Password Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-login-password-skull.svg" alt="Login Password Skull" />
+      <img src="/brand-icons/f5-icon-security-login-password-skull.svg" alt="Login Password Skull" />
     </div>
     <div class="icon-card-label">Login Password Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-password.svg" alt="Password" />
+      <img src="/brand-icons/f5-icon-security-password.svg" alt="Password" />
     </div>
     <div class="icon-card-label">Password</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-password-bot.svg" alt="Password Bot" />
+      <img src="/brand-icons/f5-icon-security-password-bot.svg" alt="Password Bot" />
     </div>
     <div class="icon-card-label">Password Bot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-password-lock.svg" alt="Password Lock" />
+      <img src="/brand-icons/f5-icon-security-password-lock.svg" alt="Password Lock" />
     </div>
     <div class="icon-card-label">Password Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-password-skull.svg" alt="Password Skull" />
+      <img src="/brand-icons/f5-icon-security-password-skull.svg" alt="Password Skull" />
     </div>
     <div class="icon-card-label">Password Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-pattern-matching.svg" alt="Pattern Matching" />
+      <img src="/brand-icons/f5-icon-security-pattern-matching.svg" alt="Pattern Matching" />
     </div>
     <div class="icon-card-label">Pattern Matching</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-performance-bot.svg" alt="Performance Bot" />
+      <img src="/brand-icons/f5-icon-security-performance-bot.svg" alt="Performance Bot" />
     </div>
     <div class="icon-card-label">Performance Bot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-phishing.svg" alt="Phishing" />
+      <img src="/brand-icons/f5-icon-security-phishing.svg" alt="Phishing" />
     </div>
     <div class="icon-card-label">Phishing</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-reverse-proxy.svg" alt="Reverse Proxy" />
+      <img src="/brand-icons/f5-icon-security-reverse-proxy.svg" alt="Reverse Proxy" />
     </div>
     <div class="icon-card-label">Reverse Proxy</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-ribbon-checkmark.svg" alt="Ribbon Checkmark" />
+      <img src="/brand-icons/f5-icon-security-ribbon-checkmark.svg" alt="Ribbon Checkmark" />
     </div>
     <div class="icon-card-label">Ribbon Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-rotating-arrows-bot.svg" alt="Rotating Arrows Bot" />
+      <img src="/brand-icons/f5-icon-security-rotating-arrows-bot.svg" alt="Rotating Arrows Bot" />
     </div>
     <div class="icon-card-label">Rotating Arrows Bot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-rotating-arrows-unlocked.svg" alt="Rotating Arrows Unlocked" />
+      <img src="/brand-icons/f5-icon-security-rotating-arrows-unlocked.svg" alt="Rotating Arrows Unlocked" />
     </div>
     <div class="icon-card-label">Rotating Arrows Unlocked</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-safe.svg" alt="Safe" />
+      <img src="/brand-icons/f5-icon-security-safe.svg" alt="Safe" />
     </div>
     <div class="icon-card-label">Safe</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-security-secure-data-connectivity.svg" alt="Secure Data Connectivity" />
+      <img src="/brand-icons/f5-security-secure-data-connectivity.svg" alt="Secure Data Connectivity" />
     </div>
     <div class="icon-card-label">Secure Data Connectivity</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shapes-lock-arrows.svg" alt="Shapes Lock Arrows" />
+      <img src="/brand-icons/f5-icon-security-shapes-lock-arrows.svg" alt="Shapes Lock Arrows" />
     </div>
     <div class="icon-card-label">Shapes Lock Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-7.svg" alt="Shield 7" />
+      <img src="/brand-icons/f5-icon-security-shield-7.svg" alt="Shield 7" />
     </div>
     <div class="icon-card-label">Shield 7</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-app-code.svg" alt="Shield App Code" />
+      <img src="/brand-icons/f5-icon-security-shield-app-code.svg" alt="Shield App Code" />
     </div>
     <div class="icon-card-label">Shield App Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-bot.svg" alt="Shield Bot" />
+      <img src="/brand-icons/f5-icon-security-shield-bot.svg" alt="Shield Bot" />
     </div>
     <div class="icon-card-label">Shield Bot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-checkmark.svg" alt="Shield Checkmark" />
+      <img src="/brand-icons/f5-icon-security-shield-checkmark.svg" alt="Shield Checkmark" />
     </div>
     <div class="icon-card-label">Shield Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-checkmark-arrows.svg" alt="Shield Checkmark Arrows" />
+      <img src="/brand-icons/f5-icon-security-shield-checkmark-arrows.svg" alt="Shield Checkmark Arrows" />
     </div>
     <div class="icon-card-label">Shield Checkmark Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-dns.svg" alt="Shield Dns" />
+      <img src="/brand-icons/f5-icon-security-shield-dns.svg" alt="Shield Dns" />
     </div>
     <div class="icon-card-label">Shield Dns</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-gear-rotating-arrows.svg" alt="Shield Gear Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-security-shield-gear-rotating-arrows.svg" alt="Shield Gear Rotating Arrows" />
     </div>
     <div class="icon-card-label">Shield Gear Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-magnifying-code.svg" alt="Shield Magnifying Code" />
+      <img src="/brand-icons/f5-icon-security-shield-magnifying-code.svg" alt="Shield Magnifying Code" />
     </div>
     <div class="icon-card-label">Shield Magnifying Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-network.svg" alt="Shield Network" />
+      <img src="/brand-icons/f5-icon-security-shield-network.svg" alt="Shield Network" />
     </div>
     <div class="icon-card-label">Shield Network</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-performance.svg" alt="Shield Performance" />
+      <img src="/brand-icons/f5-icon-security-shield-performance.svg" alt="Shield Performance" />
     </div>
     <div class="icon-card-label">Shield Performance</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-rotating-arrows.svg" alt="Shield Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-security-shield-rotating-arrows.svg" alt="Shield Rotating Arrows" />
     </div>
     <div class="icon-card-label">Shield Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-stack.svg" alt="Shield Stack" />
+      <img src="/brand-icons/f5-icon-security-shield-stack.svg" alt="Shield Stack" />
     </div>
     <div class="icon-card-label">Shield Stack</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-vpn.svg" alt="Shield Vpn" />
+      <img src="/brand-icons/f5-icon-security-shield-vpn.svg" alt="Shield Vpn" />
     </div>
     <div class="icon-card-label">Shield Vpn</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-shield-wifi.svg" alt="Shield Wifi" />
+      <img src="/brand-icons/f5-icon-security-shield-wifi.svg" alt="Shield Wifi" />
     </div>
     <div class="icon-card-label">Shield Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-site-key.svg" alt="Site Key" />
+      <img src="/brand-icons/f5-icon-security-site-key.svg" alt="Site Key" />
     </div>
     <div class="icon-card-label">Site Key</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-site-lock-1.svg" alt="Site Lock 1" />
+      <img src="/brand-icons/f5-icon-security-site-lock-1.svg" alt="Site Lock 1" />
     </div>
     <div class="icon-card-label">Site Lock 1</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-site-lock-2.svg" alt="Site Lock 2" />
+      <img src="/brand-icons/f5-icon-security-site-lock-2.svg" alt="Site Lock 2" />
     </div>
     <div class="icon-card-label">Site Lock 2</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-site-scrubbing.svg" alt="Site Scrubbing" />
+      <img src="/brand-icons/f5-icon-security-site-scrubbing.svg" alt="Site Scrubbing" />
     </div>
     <div class="icon-card-label">Site Scrubbing</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-site-shield.svg" alt="Site Shield" />
+      <img src="/brand-icons/f5-icon-security-site-shield.svg" alt="Site Shield" />
     </div>
     <div class="icon-card-label">Site Shield</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-site-skull.svg" alt="Site Skull" />
+      <img src="/brand-icons/f5-icon-security-site-skull.svg" alt="Site Skull" />
     </div>
     <div class="icon-card-label">Site Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-site-skull-code.svg" alt="Site Skull Code" />
+      <img src="/brand-icons/f5-icon-security-site-skull-code.svg" alt="Site Skull Code" />
     </div>
     <div class="icon-card-label">Site Skull Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-site-target.svg" alt="Site Target" />
+      <img src="/brand-icons/f5-icon-security-site-target.svg" alt="Site Target" />
     </div>
     <div class="icon-card-label">Site Target</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-skull.svg" alt="Skull" />
+      <img src="/brand-icons/f5-icon-security-skull.svg" alt="Skull" />
     </div>
     <div class="icon-card-label">Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-unlock.svg" alt="Unlock" />
+      <img src="/brand-icons/f5-icon-security-unlock.svg" alt="Unlock" />
     </div>
     <div class="icon-card-label">Unlock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-unlock-crossing-arrows.svg" alt="Unlock Crossing Arrows" />
+      <img src="/brand-icons/f5-icon-security-unlock-crossing-arrows.svg" alt="Unlock Crossing Arrows" />
     </div>
     <div class="icon-card-label">Unlock Crossing Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-security-video-sensor.svg" alt="Video Sensor" />
+      <img src="/brand-icons/f5-icon-security-video-sensor.svg" alt="Video Sensor" />
     </div>
     <div class="icon-card-label">Video Sensor</div>
   </div>
@@ -2532,97 +2532,97 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-beacon.svg" alt="Beacon" />
+      <img src="/brand-icons/f5-icon-service-beacon.svg" alt="Beacon" />
     </div>
     <div class="icon-card-label">Beacon</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-big-ip-next.svg" alt="Big Ip Next" />
+      <img src="/brand-icons/f5-icon-service-big-ip-next.svg" alt="Big Ip Next" />
     </div>
     <div class="icon-card-label">Big Ip Next</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-f5.svg" alt="F5" />
+      <img src="/brand-icons/f5-icon-service-f5.svg" alt="F5" />
     </div>
     <div class="icon-card-label">F5</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-nginx.svg" alt="Nginx" />
+      <img src="/brand-icons/f5-icon-service-nginx.svg" alt="Nginx" />
     </div>
     <div class="icon-card-label">Nginx</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-nginx-amplify.svg" alt="Nginx Amplify" />
+      <img src="/brand-icons/f5-icon-service-nginx-amplify.svg" alt="Nginx Amplify" />
     </div>
     <div class="icon-card-label">Nginx Amplify</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-nginx-api-connectivity.svg" alt="Nginx Api Connectivity" />
+      <img src="/brand-icons/f5-icon-service-nginx-api-connectivity.svg" alt="Nginx Api Connectivity" />
     </div>
     <div class="icon-card-label">Nginx Api Connectivity</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-nginx-app-delivery-manager.svg" alt="Nginx App Delivery Manager" />
+      <img src="/brand-icons/f5-icon-service-nginx-app-delivery-manager.svg" alt="Nginx App Delivery Manager" />
     </div>
     <div class="icon-card-label">Nginx App Delivery Manager</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-nginx-app-protect.svg" alt="Nginx App Protect" />
+      <img src="/brand-icons/f5-icon-service-nginx-app-protect.svg" alt="Nginx App Protect" />
     </div>
     <div class="icon-card-label">Nginx App Protect</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-nginx-ingress-controller.svg" alt="Nginx Ingress Controller" />
+      <img src="/brand-icons/f5-icon-service-nginx-ingress-controller.svg" alt="Nginx Ingress Controller" />
     </div>
     <div class="icon-card-label">Nginx Ingress Controller</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-nginx-instance-manager.svg" alt="Nginx Instance Manager" />
+      <img src="/brand-icons/f5-icon-service-nginx-instance-manager.svg" alt="Nginx Instance Manager" />
     </div>
     <div class="icon-card-label">Nginx Instance Manager</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-nginx-management-suite.svg" alt="Nginx Management Suite" />
+      <img src="/brand-icons/f5-icon-service-nginx-management-suite.svg" alt="Nginx Management Suite" />
     </div>
     <div class="icon-card-label">Nginx Management Suite</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-nginx-mesh.svg" alt="Nginx Mesh" />
+      <img src="/brand-icons/f5-icon-service-nginx-mesh.svg" alt="Nginx Mesh" />
     </div>
     <div class="icon-card-label">Nginx Mesh</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-nginx-n-plus.svg" alt="Nginx N Plus" />
+      <img src="/brand-icons/f5-icon-service-nginx-n-plus.svg" alt="Nginx N Plus" />
     </div>
     <div class="icon-card-label">Nginx N Plus</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-open-source.svg" alt="Open Source" />
+      <img src="/brand-icons/f5-icon-service-open-source.svg" alt="Open Source" />
     </div>
     <div class="icon-card-label">Open Source</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-openshift.svg" alt="Openshift" />
+      <img src="/brand-icons/f5-icon-service-openshift.svg" alt="Openshift" />
     </div>
     <div class="icon-card-label">Openshift</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-service-openstack.svg" alt="Openstack" />
+      <img src="/brand-icons/f5-icon-service-openstack.svg" alt="Openstack" />
     </div>
     <div class="icon-card-label">Openstack</div>
   </div>
@@ -2634,331 +2634,331 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-accessibility.svg" alt="Accessibility" />
+      <img src="/brand-icons/f5-icon-user-accessibility.svg" alt="Accessibility" />
     </div>
     <div class="icon-card-label">Accessibility</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-accessibility-arrows.svg" alt="Accessibility Arrows" />
+      <img src="/brand-icons/f5-icon-user-accessibility-arrows.svg" alt="Accessibility Arrows" />
     </div>
     <div class="icon-card-label">Accessibility Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-admin.svg" alt="Admin" />
+      <img src="/brand-icons/f5-icon-user-admin.svg" alt="Admin" />
     </div>
     <div class="icon-card-label">Admin</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-user-ai-agent-manager.svg" alt="Ai Agent Manager" />
+      <img src="/brand-icons/f5-user-ai-agent-manager.svg" alt="Ai Agent Manager" />
     </div>
     <div class="icon-card-label">Ai Agent Manager</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-app.svg" alt="App" />
+      <img src="/brand-icons/f5-icon-user-app.svg" alt="App" />
     </div>
     <div class="icon-card-label">App</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-app-key.svg" alt="App Key" />
+      <img src="/brand-icons/f5-icon-user-app-key.svg" alt="App Key" />
     </div>
     <div class="icon-card-label">App Key</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-arrow-sheild.svg" alt="Arrow Sheild" />
+      <img src="/brand-icons/f5-icon-user-arrow-sheild.svg" alt="Arrow Sheild" />
     </div>
     <div class="icon-card-label">Arrow Sheild</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-arrow-up.svg" alt="Arrow Up" />
+      <img src="/brand-icons/f5-icon-user-arrow-up.svg" alt="Arrow Up" />
     </div>
     <div class="icon-card-label">Arrow Up</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-arrows-rotating.svg" alt="Arrows Rotating" />
+      <img src="/brand-icons/f5-icon-user-arrows-rotating.svg" alt="Arrows Rotating" />
     </div>
     <div class="icon-card-label">Arrows Rotating</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-b2b.svg" alt="B2B" />
+      <img src="/brand-icons/f5-icon-user-b2b.svg" alt="B2B" />
     </div>
     <div class="icon-card-label">B2B</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-chat-bubble.svg" alt="Chat Bubble" />
+      <img src="/brand-icons/f5-icon-user-chat-bubble.svg" alt="Chat Bubble" />
     </div>
     <div class="icon-card-label">Chat Bubble</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-checkmark.svg" alt="Checkmark" />
+      <img src="/brand-icons/f5-icon-user-checkmark.svg" alt="Checkmark" />
     </div>
     <div class="icon-card-label">Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-circle-arrow-rotating.svg" alt="Circle Arrow Rotating" />
+      <img src="/brand-icons/f5-icon-user-circle-arrow-rotating.svg" alt="Circle Arrow Rotating" />
     </div>
     <div class="icon-card-label">Circle Arrow Rotating</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-circle-arrows.svg" alt="Circle Arrows" />
+      <img src="/brand-icons/f5-icon-user-circle-arrows.svg" alt="Circle Arrows" />
     </div>
     <div class="icon-card-label">Circle Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-clock-rotating-arrow.svg" alt="Clock Rotating Arrow" />
+      <img src="/brand-icons/f5-icon-user-clock-rotating-arrow.svg" alt="Clock Rotating Arrow" />
     </div>
     <div class="icon-card-label">Clock Rotating Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-cloud.svg" alt="Cloud" />
+      <img src="/brand-icons/f5-icon-user-cloud.svg" alt="Cloud" />
     </div>
     <div class="icon-card-label">Cloud</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-cloud-with-arrow.svg" alt="Cloud With Arrow" />
+      <img src="/brand-icons/f5-icon-user-cloud-with-arrow.svg" alt="Cloud With Arrow" />
     </div>
     <div class="icon-card-label">Cloud With Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-code.svg" alt="Code" />
+      <img src="/brand-icons/f5-icon-user-code.svg" alt="Code" />
     </div>
     <div class="icon-card-label">Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-code-presentation.svg" alt="Code Presentation" />
+      <img src="/brand-icons/f5-icon-user-code-presentation.svg" alt="Code Presentation" />
     </div>
     <div class="icon-card-label">Code Presentation</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-cog.svg" alt="Cog" />
+      <img src="/brand-icons/f5-icon-user-cog.svg" alt="Cog" />
     </div>
     <div class="icon-card-label">Cog</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-cog-rotating-arrows.svg" alt="Cog Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-user-cog-rotating-arrows.svg" alt="Cog Rotating Arrows" />
     </div>
     <div class="icon-card-label">Cog Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-cog-with-arrows.svg" alt="Cog With Arrows" />
+      <img src="/brand-icons/f5-icon-user-cog-with-arrows.svg" alt="Cog With Arrows" />
     </div>
     <div class="icon-card-label">Cog With Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-customer-decision.svg" alt="Customer Decision" />
+      <img src="/brand-icons/f5-icon-user-customer-decision.svg" alt="Customer Decision" />
     </div>
     <div class="icon-card-label">Customer Decision</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-customer-service-clock.svg" alt="Customer Service Clock" />
+      <img src="/brand-icons/f5-icon-user-customer-service-clock.svg" alt="Customer Service Clock" />
     </div>
     <div class="icon-card-label">Customer Service Clock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-customer-service-shield.svg" alt="Customer Service Shield" />
+      <img src="/brand-icons/f5-icon-user-customer-service-shield.svg" alt="Customer Service Shield" />
     </div>
     <div class="icon-card-label">Customer Service Shield</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-doc-checkmark.svg" alt="Doc Checkmark" />
+      <img src="/brand-icons/f5-icon-user-doc-checkmark.svg" alt="Doc Checkmark" />
     </div>
     <div class="icon-card-label">Doc Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-globe.svg" alt="Globe" />
+      <img src="/brand-icons/f5-icon-user-globe.svg" alt="Globe" />
     </div>
     <div class="icon-card-label">Globe</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-globe-rotating-arrows.svg" alt="Globe Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-user-globe-rotating-arrows.svg" alt="Globe Rotating Arrows" />
     </div>
     <div class="icon-card-label">Globe Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-graphs-data.svg" alt="Graphs Data" />
+      <img src="/brand-icons/f5-icon-user-graphs-data.svg" alt="Graphs Data" />
     </div>
     <div class="icon-card-label">Graphs Data</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-heart.svg" alt="Heart" />
+      <img src="/brand-icons/f5-icon-user-heart.svg" alt="Heart" />
     </div>
     <div class="icon-card-label">Heart</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-in-arrows-rotating.svg" alt="In Arrows Rotating" />
+      <img src="/brand-icons/f5-icon-user-in-arrows-rotating.svg" alt="In Arrows Rotating" />
     </div>
     <div class="icon-card-label">In Arrows Rotating</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-in-circle.svg" alt="In Circle" />
+      <img src="/brand-icons/f5-icon-user-in-circle.svg" alt="In Circle" />
     </div>
     <div class="icon-card-label">In Circle</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-laptop-arrows.svg" alt="Laptop Arrows" />
+      <img src="/brand-icons/f5-icon-user-laptop-arrows.svg" alt="Laptop Arrows" />
     </div>
     <div class="icon-card-label">Laptop Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-laptop-code.svg" alt="Laptop Code" />
+      <img src="/brand-icons/f5-icon-user-laptop-code.svg" alt="Laptop Code" />
     </div>
     <div class="icon-card-label">Laptop Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-lock-cog-with-arrows.svg" alt="Lock Cog With Arrows" />
+      <img src="/brand-icons/f5-icon-user-lock-cog-with-arrows.svg" alt="Lock Cog With Arrows" />
     </div>
     <div class="icon-card-label">Lock Cog With Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-magnifying-glass.svg" alt="Magnifying Glass" />
+      <img src="/brand-icons/f5-icon-user-magnifying-glass.svg" alt="Magnifying Glass" />
     </div>
     <div class="icon-card-label">Magnifying Glass</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-money.svg" alt="Money" />
+      <img src="/brand-icons/f5-icon-user-money.svg" alt="Money" />
     </div>
     <div class="icon-card-label">Money</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-money-rotating-arrows.svg" alt="Money Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-user-money-rotating-arrows.svg" alt="Money Rotating Arrows" />
     </div>
     <div class="icon-card-label">Money Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-network.svg" alt="Network" />
+      <img src="/brand-icons/f5-icon-user-network.svg" alt="Network" />
     </div>
     <div class="icon-card-label">Network</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-no.svg" alt="No" />
+      <img src="/brand-icons/f5-icon-user-no.svg" alt="No" />
     </div>
     <div class="icon-card-label">No</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-phone-wifi.svg" alt="Phone Wifi" />
+      <img src="/brand-icons/f5-icon-user-phone-wifi.svg" alt="Phone Wifi" />
     </div>
     <div class="icon-card-label">Phone Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-question-mark.svg" alt="Question Mark" />
+      <img src="/brand-icons/f5-icon-user-question-mark.svg" alt="Question Mark" />
     </div>
     <div class="icon-card-label">Question Mark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-scale.svg" alt="Scale" />
+      <img src="/brand-icons/f5-icon-user-scale.svg" alt="Scale" />
     </div>
     <div class="icon-card-label">Scale</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-servers-cog.svg" alt="Servers Cog" />
+      <img src="/brand-icons/f5-icon-user-servers-cog.svg" alt="Servers Cog" />
     </div>
     <div class="icon-card-label">Servers Cog</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-servers-infinity-cog.svg" alt="Servers Infinity Cog" />
+      <img src="/brand-icons/f5-icon-user-servers-infinity-cog.svg" alt="Servers Infinity Cog" />
     </div>
     <div class="icon-card-label">Servers Infinity Cog</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-shield-checkmark-rotating-arrows.svg" alt="Shield Checkmark Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-user-shield-checkmark-rotating-arrows.svg" alt="Shield Checkmark Rotating Arrows" />
     </div>
     <div class="icon-card-label">Shield Checkmark Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-shield-with-checkmark.svg" alt="Shield With Checkmark" />
+      <img src="/brand-icons/f5-icon-user-shield-with-checkmark.svg" alt="Shield With Checkmark" />
     </div>
     <div class="icon-card-label">Shield With Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-skull.svg" alt="Skull" />
+      <img src="/brand-icons/f5-icon-user-skull.svg" alt="Skull" />
     </div>
     <div class="icon-card-label">Skull</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-star.svg" alt="Star" />
+      <img src="/brand-icons/f5-icon-user-star.svg" alt="Star" />
     </div>
     <div class="icon-card-label">Star</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-support.svg" alt="Support" />
+      <img src="/brand-icons/f5-icon-user-support.svg" alt="Support" />
     </div>
     <div class="icon-card-label">Support</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-third-party.svg" alt="Third Party" />
+      <img src="/brand-icons/f5-icon-user-third-party.svg" alt="Third Party" />
     </div>
     <div class="icon-card-label">Third Party</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-user.svg" alt="User" />
+      <img src="/brand-icons/f5-icon-user-user.svg" alt="User" />
     </div>
     <div class="icon-card-label">User</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-ux.svg" alt="Ux" />
+      <img src="/brand-icons/f5-icon-user-ux.svg" alt="Ux" />
     </div>
     <div class="icon-card-label">Ux</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-wrench.svg" alt="Wrench" />
+      <img src="/brand-icons/f5-icon-user-wrench.svg" alt="Wrench" />
     </div>
     <div class="icon-card-label">Wrench</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user-yes-no.svg" alt="Yes No" />
+      <img src="/brand-icons/f5-icon-user-yes-no.svg" alt="Yes No" />
     </div>
     <div class="icon-card-label">Yes No</div>
   </div>
@@ -2970,1093 +2970,1093 @@ The Icon library provides 50×50 SVG line-art icons covering networking, securit
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-3-bars.svg" alt="3 Bars" />
+      <img src="/brand-icons/f5-icon-other-3-bars.svg" alt="3 Bars" />
     </div>
     <div class="icon-card-label">3 Bars</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-a-b-testing.svg" alt="A B Testing" />
+      <img src="/brand-icons/f5-icon-other-a-b-testing.svg" alt="A B Testing" />
     </div>
     <div class="icon-card-label">A B Testing</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-a-b-testing-1.svg" alt="A B Testing 1" />
+      <img src="/brand-icons/f5-icon-other-a-b-testing-1.svg" alt="A B Testing 1" />
     </div>
     <div class="icon-card-label">A B Testing 1</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-app-delivery.svg" alt="App Delivery" />
+      <img src="/brand-icons/f5-other-app-delivery.svg" alt="App Delivery" />
     </div>
     <div class="icon-card-label">App Delivery</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-arrow-diagonal-right.svg" alt="Arrow Diagonal Right" />
+      <img src="/brand-icons/f5-icon-other-arrow-diagonal-right.svg" alt="Arrow Diagonal Right" />
     </div>
     <div class="icon-card-label">Arrow Diagonal Right</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-atm-mobile.svg" alt="Atm Mobile" />
+      <img src="/brand-icons/f5-icon-other-atm-mobile.svg" alt="Atm Mobile" />
     </div>
     <div class="icon-card-label">Atm Mobile</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-bar-graph.svg" alt="Bar Graph" />
+      <img src="/brand-icons/f5-icon-other-bar-graph.svg" alt="Bar Graph" />
     </div>
     <div class="icon-card-label">Bar Graph</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-bar-graph-up-arrow.svg" alt="Bar Graph Up Arrow" />
+      <img src="/brand-icons/f5-icon-other-bar-graph-up-arrow.svg" alt="Bar Graph Up Arrow" />
     </div>
     <div class="icon-card-label">Bar Graph Up Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-bar-graph-wifi.svg" alt="Bar Graph Wifi" />
+      <img src="/brand-icons/f5-icon-other-bar-graph-wifi.svg" alt="Bar Graph Wifi" />
     </div>
     <div class="icon-card-label">Bar Graph Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-bar-line-graphs.svg" alt="Bar Line Graphs" />
+      <img src="/brand-icons/f5-icon-other-bar-line-graphs.svg" alt="Bar Line Graphs" />
     </div>
     <div class="icon-card-label">Bar Line Graphs</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-bed-hotel.svg" alt="Bed Hotel" />
+      <img src="/brand-icons/f5-icon-other-bed-hotel.svg" alt="Bed Hotel" />
     </div>
     <div class="icon-card-label">Bed Hotel</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-bell.svg" alt="Bell" />
+      <img src="/brand-icons/f5-other-bell.svg" alt="Bell" />
     </div>
     <div class="icon-card-label">Bell</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-bitcoin.svg" alt="Bitcoin" />
+      <img src="/brand-icons/f5-icon-other-bitcoin.svg" alt="Bitcoin" />
     </div>
     <div class="icon-card-label">Bitcoin</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-blog.svg" alt="Blog" />
+      <img src="/brand-icons/f5-icon-other-blog.svg" alt="Blog" />
     </div>
     <div class="icon-card-label">Blog</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-blue-green-deployment.svg" alt="Blue Green Deployment" />
+      <img src="/brand-icons/f5-icon-other-blue-green-deployment.svg" alt="Blue Green Deployment" />
     </div>
     <div class="icon-card-label">Blue Green Deployment</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-bolt.svg" alt="Bolt" />
+      <img src="/brand-icons/f5-icon-other-bolt.svg" alt="Bolt" />
     </div>
     <div class="icon-card-label">Bolt</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-book.svg" alt="Book" />
+      <img src="/brand-icons/f5-icon-other-book.svg" alt="Book" />
     </div>
     <div class="icon-card-label">Book</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-box.svg" alt="Box" />
+      <img src="/brand-icons/f5-icon-other-box.svg" alt="Box" />
     </div>
     <div class="icon-card-label">Box</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-brain.svg" alt="Brain" />
+      <img src="/brand-icons/f5-icon-other-brain.svg" alt="Brain" />
     </div>
     <div class="icon-card-label">Brain</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-brain-tech-learning-nodes.svg" alt="Brain Tech Learning Nodes" />
+      <img src="/brand-icons/f5-icon-other-brain-tech-learning-nodes.svg" alt="Brain Tech Learning Nodes" />
     </div>
     <div class="icon-card-label">Brain Tech Learning Nodes</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-calendar.svg" alt="Calendar" />
+      <img src="/brand-icons/f5-icon-other-calendar.svg" alt="Calendar" />
     </div>
     <div class="icon-card-label">Calendar</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-camera.svg" alt="Camera" />
+      <img src="/brand-icons/f5-icon-other-camera.svg" alt="Camera" />
     </div>
     <div class="icon-card-label">Camera</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-camera-app.svg" alt="Camera App" />
+      <img src="/brand-icons/f5-icon-other-camera-app.svg" alt="Camera App" />
     </div>
     <div class="icon-card-label">Camera App</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-car.svg" alt="Car" />
+      <img src="/brand-icons/f5-icon-other-car.svg" alt="Car" />
     </div>
     <div class="icon-card-label">Car</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-car-wifi.svg" alt="Car Wifi" />
+      <img src="/brand-icons/f5-icon-other-car-wifi.svg" alt="Car Wifi" />
     </div>
     <div class="icon-card-label">Car Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-checkmark.svg" alt="Checkmark" />
+      <img src="/brand-icons/f5-icon-other-checkmark.svg" alt="Checkmark" />
     </div>
     <div class="icon-card-label">Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-chess-knight.svg" alt="Chess Knight" />
+      <img src="/brand-icons/f5-icon-other-chess-knight.svg" alt="Chess Knight" />
     </div>
     <div class="icon-card-label">Chess Knight</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-clipboard-list.svg" alt="Clipboard List" />
+      <img src="/brand-icons/f5-icon-other-clipboard-list.svg" alt="Clipboard List" />
     </div>
     <div class="icon-card-label">Clipboard List</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-clippboard-prize.svg" alt="Clippboard Prize" />
+      <img src="/brand-icons/f5-icon-other-clippboard-prize.svg" alt="Clippboard Prize" />
     </div>
     <div class="icon-card-label">Clippboard Prize</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-clock.svg" alt="Clock" />
+      <img src="/brand-icons/f5-icon-other-clock.svg" alt="Clock" />
     </div>
     <div class="icon-card-label">Clock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-clock-down-arrow.svg" alt="Clock Down Arrow" />
+      <img src="/brand-icons/f5-icon-other-clock-down-arrow.svg" alt="Clock Down Arrow" />
     </div>
     <div class="icon-card-label">Clock Down Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-clocl-rotating-arrows.svg" alt="Clocl Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-other-clocl-rotating-arrows.svg" alt="Clocl Rotating Arrows" />
     </div>
     <div class="icon-card-label">Clocl Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-code-talk-bubble.svg" alt="Code Talk Bubble" />
+      <img src="/brand-icons/f5-icon-other-code-talk-bubble.svg" alt="Code Talk Bubble" />
     </div>
     <div class="icon-card-label">Code Talk Bubble</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-compass-guidance-direction.svg" alt="Compass Guidance Direction" />
+      <img src="/brand-icons/f5-icon-other-compass-guidance-direction.svg" alt="Compass Guidance Direction" />
     </div>
     <div class="icon-card-label">Compass Guidance Direction</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-complexity-maze.svg" alt="Complexity Maze" />
+      <img src="/brand-icons/f5-icon-other-complexity-maze.svg" alt="Complexity Maze" />
     </div>
     <div class="icon-card-label">Complexity Maze</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-corporate-buildings.svg" alt="Corporate Buildings" />
+      <img src="/brand-icons/f5-icon-other-corporate-buildings.svg" alt="Corporate Buildings" />
     </div>
     <div class="icon-card-label">Corporate Buildings</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-credit-card.svg" alt="Credit Card" />
+      <img src="/brand-icons/f5-icon-other-credit-card.svg" alt="Credit Card" />
     </div>
     <div class="icon-card-label">Credit Card</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-currency-down-arrow.svg" alt="Currency Down Arrow" />
+      <img src="/brand-icons/f5-icon-other-currency-down-arrow.svg" alt="Currency Down Arrow" />
     </div>
     <div class="icon-card-label">Currency Down Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-delivery-truck.svg" alt="Delivery Truck" />
+      <img src="/brand-icons/f5-icon-other-delivery-truck.svg" alt="Delivery Truck" />
     </div>
     <div class="icon-card-label">Delivery Truck</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-demon.svg" alt="Demon" />
+      <img src="/brand-icons/f5-icon-other-demon.svg" alt="Demon" />
     </div>
     <div class="icon-card-label">Demon</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-do-not.svg" alt="Do Not" />
+      <img src="/brand-icons/f5-icon-other-do-not.svg" alt="Do Not" />
     </div>
     <div class="icon-card-label">Do Not</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-do-not-rotating-arrows.svg" alt="Do Not Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-other-do-not-rotating-arrows.svg" alt="Do Not Rotating Arrows" />
     </div>
     <div class="icon-card-label">Do Not Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-checklist.svg" alt="Doc Checklist" />
+      <img src="/brand-icons/f5-icon-other-doc-checklist.svg" alt="Doc Checklist" />
     </div>
     <div class="icon-card-label">Doc Checklist</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-checkmark.svg" alt="Doc Checkmark" />
+      <img src="/brand-icons/f5-icon-other-doc-checkmark.svg" alt="Doc Checkmark" />
     </div>
     <div class="icon-card-label">Doc Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-code.svg" alt="Doc Code" />
+      <img src="/brand-icons/f5-icon-other-doc-code.svg" alt="Doc Code" />
     </div>
     <div class="icon-card-label">Doc Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-datasheet.svg" alt="Doc Datasheet" />
+      <img src="/brand-icons/f5-icon-other-doc-datasheet.svg" alt="Doc Datasheet" />
     </div>
     <div class="icon-card-label">Doc Datasheet</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-health.svg" alt="Doc Health" />
+      <img src="/brand-icons/f5-icon-other-doc-health.svg" alt="Doc Health" />
     </div>
     <div class="icon-card-label">Doc Health</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-infographics.svg" alt="Doc Infographics" />
+      <img src="/brand-icons/f5-icon-other-doc-infographics.svg" alt="Doc Infographics" />
     </div>
     <div class="icon-card-label">Doc Infographics</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-lightbulb.svg" alt="Doc Lightbulb" />
+      <img src="/brand-icons/f5-icon-other-doc-lightbulb.svg" alt="Doc Lightbulb" />
     </div>
     <div class="icon-card-label">Doc Lightbulb</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-lock.svg" alt="Doc Lock" />
+      <img src="/brand-icons/f5-icon-other-doc-lock.svg" alt="Doc Lock" />
     </div>
     <div class="icon-card-label">Doc Lock</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-magnifying-fingerprint.svg" alt="Doc Magnifying Fingerprint" />
+      <img src="/brand-icons/f5-icon-other-doc-magnifying-fingerprint.svg" alt="Doc Magnifying Fingerprint" />
     </div>
     <div class="icon-card-label">Doc Magnifying Fingerprint</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-network.svg" alt="Doc Network" />
+      <img src="/brand-icons/f5-icon-other-doc-network.svg" alt="Doc Network" />
     </div>
     <div class="icon-card-label">Doc Network</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-prize.svg" alt="Doc Prize" />
+      <img src="/brand-icons/f5-icon-other-doc-prize.svg" alt="Doc Prize" />
     </div>
     <div class="icon-card-label">Doc Prize</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-rotating-arrows.svg" alt="Doc Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-other-doc-rotating-arrows.svg" alt="Doc Rotating Arrows" />
     </div>
     <div class="icon-card-label">Doc Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-rotating-arrows_1.svg" alt="Doc Rotating Arrows_1" />
+      <img src="/brand-icons/f5-icon-other-doc-rotating-arrows_1.svg" alt="Doc Rotating Arrows_1" />
     </div>
     <div class="icon-card-label">Doc Rotating Arrows_1</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-text.svg" alt="Doc Text" />
+      <img src="/brand-icons/f5-icon-other-doc-text.svg" alt="Doc Text" />
     </div>
     <div class="icon-card-label">Doc Text</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-user-profile.svg" alt="Doc User Profile" />
+      <img src="/brand-icons/f5-icon-other-doc-user-profile.svg" alt="Doc User Profile" />
     </div>
     <div class="icon-card-label">Doc User Profile</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-doc-whitepaper.svg" alt="Doc Whitepaper" />
+      <img src="/brand-icons/f5-icon-other-doc-whitepaper.svg" alt="Doc Whitepaper" />
     </div>
     <div class="icon-card-label">Doc Whitepaper</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-document.svg" alt="Document" />
+      <img src="/brand-icons/f5-icon-other-document.svg" alt="Document" />
     </div>
     <div class="icon-card-label">Document</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-dollar-sign.svg" alt="Dollar Sign" />
+      <img src="/brand-icons/f5-icon-other-dollar-sign.svg" alt="Dollar Sign" />
     </div>
     <div class="icon-card-label">Dollar Sign</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-door-with-arrow.svg" alt="Door With Arrow" />
+      <img src="/brand-icons/f5-icon-other-door-with-arrow.svg" alt="Door With Arrow" />
     </div>
     <div class="icon-card-label">Door With Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-download-arrow-down.svg" alt="Download Arrow Down" />
+      <img src="/brand-icons/f5-icon-other-download-arrow-down.svg" alt="Download Arrow Down" />
     </div>
     <div class="icon-card-label">Download Arrow Down</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-renewable-energy-solar.svg" alt="Energy Solar" />
+      <img src="/brand-icons/f5-renewable-energy-solar.svg" alt="Energy Solar" />
     </div>
     <div class="icon-card-label">Energy Solar</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-envelope.svg" alt="Envelope" />
+      <img src="/brand-icons/f5-icon-other-envelope.svg" alt="Envelope" />
     </div>
     <div class="icon-card-label">Envelope</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-envelope-arrow.svg" alt="Envelope Arrow" />
+      <img src="/brand-icons/f5-icon-other-envelope-arrow.svg" alt="Envelope Arrow" />
     </div>
     <div class="icon-card-label">Envelope Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-euro-currency-down-arrow.svg" alt="Euro Currency Down Arrow" />
+      <img src="/brand-icons/f5-icon-other-euro-currency-down-arrow.svg" alt="Euro Currency Down Arrow" />
     </div>
     <div class="icon-card-label">Euro Currency Down Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-factory.svg" alt="Factory" />
+      <img src="/brand-icons/f5-icon-other-factory.svg" alt="Factory" />
     </div>
     <div class="icon-card-label">Factory</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-factory-manufacturing.svg" alt="Factory Manufacturing" />
+      <img src="/brand-icons/f5-icon-other-factory-manufacturing.svg" alt="Factory Manufacturing" />
     </div>
     <div class="icon-card-label">Factory Manufacturing</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-featherweight.svg" alt="Featherweight" />
+      <img src="/brand-icons/f5-other-featherweight.svg" alt="Featherweight" />
     </div>
     <div class="icon-card-label">Featherweight</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-financial-building-euro.svg" alt="Financial Building Euro" />
+      <img src="/brand-icons/f5-icon-other-financial-building-euro.svg" alt="Financial Building Euro" />
     </div>
     <div class="icon-card-label">Financial Building Euro</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-financial-building-us.svg" alt="Financial Building Us" />
+      <img src="/brand-icons/f5-icon-other-financial-building-us.svg" alt="Financial Building Us" />
     </div>
     <div class="icon-card-label">Financial Building Us</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-financial-building-yen.svg" alt="Financial Building Yen" />
+      <img src="/brand-icons/f5-icon-other-financial-building-yen.svg" alt="Financial Building Yen" />
     </div>
     <div class="icon-card-label">Financial Building Yen</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-folder.svg" alt="Folder" />
+      <img src="/brand-icons/f5-other-folder.svg" alt="Folder" />
     </div>
     <div class="icon-card-label">Folder</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-game-plan-orchestrate.svg" alt="Game Plan Orchestrate" />
+      <img src="/brand-icons/f5-other-game-plan-orchestrate.svg" alt="Game Plan Orchestrate" />
     </div>
     <div class="icon-card-label">Game Plan Orchestrate</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-gear-arrow.svg" alt="Gear Arrow" />
+      <img src="/brand-icons/f5-icon-other-gear-arrow.svg" alt="Gear Arrow" />
     </div>
     <div class="icon-card-label">Gear Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-gear-dollar-sign.svg" alt="Gear Dollar Sign" />
+      <img src="/brand-icons/f5-icon-other-gear-dollar-sign.svg" alt="Gear Dollar Sign" />
     </div>
     <div class="icon-card-label">Gear Dollar Sign</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-global-currency.svg" alt="Global Currency" />
+      <img src="/brand-icons/f5-icon-other-global-currency.svg" alt="Global Currency" />
     </div>
     <div class="icon-card-label">Global Currency</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-government-building.svg" alt="Government Building" />
+      <img src="/brand-icons/f5-icon-other-government-building.svg" alt="Government Building" />
     </div>
     <div class="icon-card-label">Government Building</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-graduation-cap.svg" alt="Graduation Cap" />
+      <img src="/brand-icons/f5-icon-other-graduation-cap.svg" alt="Graduation Cap" />
     </div>
     <div class="icon-card-label">Graduation Cap</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-greenhouse.svg" alt="Greenhouse" />
+      <img src="/brand-icons/f5-icon-other-greenhouse.svg" alt="Greenhouse" />
     </div>
     <div class="icon-card-label">Greenhouse</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-guide-checkmark.svg" alt="Guide Checkmark" />
+      <img src="/brand-icons/f5-icon-other-guide-checkmark.svg" alt="Guide Checkmark" />
     </div>
     <div class="icon-card-label">Guide Checkmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-guide-deployment.svg" alt="Guide Deployment" />
+      <img src="/brand-icons/f5-icon-other-guide-deployment.svg" alt="Guide Deployment" />
     </div>
     <div class="icon-card-label">Guide Deployment</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-guide-gear.svg" alt="Guide Gear" />
+      <img src="/brand-icons/f5-icon-other-guide-gear.svg" alt="Guide Gear" />
     </div>
     <div class="icon-card-label">Guide Gear</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-guide-glossary.svg" alt="Guide Glossary" />
+      <img src="/brand-icons/f5-icon-other-guide-glossary.svg" alt="Guide Glossary" />
     </div>
     <div class="icon-card-label">Guide Glossary</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-guide-report.svg" alt="Guide Report" />
+      <img src="/brand-icons/f5-icon-other-guide-report.svg" alt="Guide Report" />
     </div>
     <div class="icon-card-label">Guide Report</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-guide-star.svg" alt="Guide Star" />
+      <img src="/brand-icons/f5-icon-other-guide-star.svg" alt="Guide Star" />
     </div>
     <div class="icon-card-label">Guide Star</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-hands.svg" alt="Hands" />
+      <img src="/brand-icons/f5-icon-other-hands.svg" alt="Hands" />
     </div>
     <div class="icon-card-label">Hands</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-happy.svg" alt="Happy" />
+      <img src="/brand-icons/f5-icon-other-happy.svg" alt="Happy" />
     </div>
     <div class="icon-card-label">Happy</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-headset.svg" alt="Headset" />
+      <img src="/brand-icons/f5-icon-other-headset.svg" alt="Headset" />
     </div>
     <div class="icon-card-label">Headset</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-health-ekg.svg" alt="Health Ekg" />
+      <img src="/brand-icons/f5-icon-other-health-ekg.svg" alt="Health Ekg" />
     </div>
     <div class="icon-card-label">Health Ekg</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-heart-hands.svg" alt="Heart Hands" />
+      <img src="/brand-icons/f5-icon-other-heart-hands.svg" alt="Heart Hands" />
     </div>
     <div class="icon-card-label">Heart Hands</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-heart-health.svg" alt="Heart Health" />
+      <img src="/brand-icons/f5-icon-other-heart-health.svg" alt="Heart Health" />
     </div>
     <div class="icon-card-label">Heart Health</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-heart-love.svg" alt="Heart Love" />
+      <img src="/brand-icons/f5-other-heart-love.svg" alt="Heart Love" />
     </div>
     <div class="icon-card-label">Heart Love</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-helm-wheel.svg" alt="Helm Wheel" />
+      <img src="/brand-icons/f5-icon-other-helm-wheel.svg" alt="Helm Wheel" />
     </div>
     <div class="icon-card-label">Helm Wheel</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-history.svg" alt="History" />
+      <img src="/brand-icons/f5-icon-other-history.svg" alt="History" />
     </div>
     <div class="icon-card-label">History</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-home.svg" alt="Home" />
+      <img src="/brand-icons/f5-other-home.svg" alt="Home" />
     </div>
     <div class="icon-card-label">Home</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-home-wifi.svg" alt="Home Wifi" />
+      <img src="/brand-icons/f5-other-home-wifi.svg" alt="Home Wifi" />
     </div>
     <div class="icon-card-label">Home Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-cloud.svg" alt="Icon Cloud" />
+      <img src="/brand-icons/f5-icon-cloud.svg" alt="Icon Cloud" />
     </div>
     <div class="icon-card-label">Icon Cloud</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-network.svg" alt="Icon Network" />
+      <img src="/brand-icons/f5-icon-network.svg" alt="Icon Network" />
     </div>
     <div class="icon-card-label">Icon Network</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-user.svg" alt="Icon User" />
+      <img src="/brand-icons/f5-icon-user.svg" alt="Icon User" />
     </div>
     <div class="icon-card-label">Icon User</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-image.svg" alt="Image" />
+      <img src="/brand-icons/f5-icon-other-image.svg" alt="Image" />
     </div>
     <div class="icon-card-label">Image</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-innovation-roadmap.svg" alt="Innovation Roadmap" />
+      <img src="/brand-icons/f5-icon-other-innovation-roadmap.svg" alt="Innovation Roadmap" />
     </div>
     <div class="icon-card-label">Innovation Roadmap</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-inspect-encrypted-traffic.svg" alt="Inspect Encrypted Traffic" />
+      <img src="/brand-icons/f5-other-inspect-encrypted-traffic.svg" alt="Inspect Encrypted Traffic" />
     </div>
     <div class="icon-card-label">Inspect Encrypted Traffic</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-iot.svg" alt="Iot" />
+      <img src="/brand-icons/f5-icon-other-iot.svg" alt="Iot" />
     </div>
     <div class="icon-card-label">Iot</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-key.svg" alt="Key" />
+      <img src="/brand-icons/f5-icon-other-key.svg" alt="Key" />
     </div>
     <div class="icon-card-label">Key</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-key-doc.svg" alt="Key Doc" />
+      <img src="/brand-icons/f5-icon-other-key-doc.svg" alt="Key Doc" />
     </div>
     <div class="icon-card-label">Key Doc</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-key-in-circle.svg" alt="Key In Circle" />
+      <img src="/brand-icons/f5-icon-other-key-in-circle.svg" alt="Key In Circle" />
     </div>
     <div class="icon-card-label">Key In Circle</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-key-rotating-arrows.svg" alt="Key Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-other-key-rotating-arrows.svg" alt="Key Rotating Arrows" />
     </div>
     <div class="icon-card-label">Key Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-life-ring.svg" alt="Life Ring" />
+      <img src="/brand-icons/f5-icon-other-life-ring.svg" alt="Life Ring" />
     </div>
     <div class="icon-card-label">Life Ring</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-lightbulb.svg" alt="Lightbulb" />
+      <img src="/brand-icons/f5-icon-other-lightbulb.svg" alt="Lightbulb" />
     </div>
     <div class="icon-card-label">Lightbulb</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-lightbulb-bolt.svg" alt="Lightbulb Bolt" />
+      <img src="/brand-icons/f5-icon-other-lightbulb-bolt.svg" alt="Lightbulb Bolt" />
     </div>
     <div class="icon-card-label">Lightbulb Bolt</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-lightbulb-dollar-sign.svg" alt="Lightbulb Dollar Sign" />
+      <img src="/brand-icons/f5-icon-other-lightbulb-dollar-sign.svg" alt="Lightbulb Dollar Sign" />
     </div>
     <div class="icon-card-label">Lightbulb Dollar Sign</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-luggage.svg" alt="Luggage" />
+      <img src="/brand-icons/f5-icon-other-luggage.svg" alt="Luggage" />
     </div>
     <div class="icon-card-label">Luggage</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-magnifying-glass.svg" alt="Magnifying Glass" />
+      <img src="/brand-icons/f5-icon-other-magnifying-glass.svg" alt="Magnifying Glass" />
     </div>
     <div class="icon-card-label">Magnifying Glass</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-magnifying-glass-code.svg" alt="Magnifying Glass Code" />
+      <img src="/brand-icons/f5-icon-other-magnifying-glass-code.svg" alt="Magnifying Glass Code" />
     </div>
     <div class="icon-card-label">Magnifying Glass Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-magnifying-glass-in-box.svg" alt="Magnifying Glass In Box" />
+      <img src="/brand-icons/f5-icon-other-magnifying-glass-in-box.svg" alt="Magnifying Glass In Box" />
     </div>
     <div class="icon-card-label">Magnifying Glass In Box</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-mailbox.svg" alt="Mailbox" />
+      <img src="/brand-icons/f5-other-mailbox.svg" alt="Mailbox" />
     </div>
     <div class="icon-card-label">Mailbox</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-megaphone.svg" alt="Megaphone" />
+      <img src="/brand-icons/f5-icon-other-megaphone.svg" alt="Megaphone" />
     </div>
     <div class="icon-card-label">Megaphone</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-microphone.svg" alt="Microphone" />
+      <img src="/brand-icons/f5-icon-other-microphone.svg" alt="Microphone" />
     </div>
     <div class="icon-card-label">Microphone</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-money-rotating-arrows.svg" alt="Money Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-other-money-rotating-arrows.svg" alt="Money Rotating Arrows" />
     </div>
     <div class="icon-card-label">Money Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-motorcycle-sidecar.svg" alt="Motorcycle Sidecar" />
+      <img src="/brand-icons/f5-icon-other-motorcycle-sidecar.svg" alt="Motorcycle Sidecar" />
     </div>
     <div class="icon-card-label">Motorcycle Sidecar</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-network-tower-cell-wifi.svg" alt="Network Tower Cell Wifi" />
+      <img src="/brand-icons/f5-other-network-tower-cell-wifi.svg" alt="Network Tower Cell Wifi" />
     </div>
     <div class="icon-card-label">Network Tower Cell Wifi</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-newspaper.svg" alt="Newspaper" />
+      <img src="/brand-icons/f5-icon-other-newspaper.svg" alt="Newspaper" />
     </div>
     <div class="icon-card-label">Newspaper</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-no-visibility-eye.svg" alt="No Visibility Eye" />
+      <img src="/brand-icons/f5-icon-other-no-visibility-eye.svg" alt="No Visibility Eye" />
     </div>
     <div class="icon-card-label">No Visibility Eye</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-oil-gas-tower.svg" alt="Oil Gas Tower" />
+      <img src="/brand-icons/f5-icon-other-oil-gas-tower.svg" alt="Oil Gas Tower" />
     </div>
     <div class="icon-card-label">Oil Gas Tower</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-pen-write.svg" alt="Pen Write" />
+      <img src="/brand-icons/f5-other-pen-write.svg" alt="Pen Write" />
     </div>
     <div class="icon-card-label">Pen Write</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-pin.svg" alt="Pin" />
+      <img src="/brand-icons/f5-icon-other-pin.svg" alt="Pin" />
     </div>
     <div class="icon-card-label">Pin</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-plane.svg" alt="Plane" />
+      <img src="/brand-icons/f5-icon-other-plane.svg" alt="Plane" />
     </div>
     <div class="icon-card-label">Plane</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-plant-thrive.svg" alt="Plant Thrive" />
+      <img src="/brand-icons/f5-icon-other-plant-thrive.svg" alt="Plant Thrive" />
     </div>
     <div class="icon-card-label">Plant Thrive</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-play.svg" alt="Play" />
+      <img src="/brand-icons/f5-icon-other-play.svg" alt="Play" />
     </div>
     <div class="icon-card-label">Play</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-positive-performance.svg" alt="Positive Performance" />
+      <img src="/brand-icons/f5-icon-other-positive-performance.svg" alt="Positive Performance" />
     </div>
     <div class="icon-card-label">Positive Performance</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-puzzle.svg" alt="Puzzle" />
+      <img src="/brand-icons/f5-icon-other-puzzle.svg" alt="Puzzle" />
     </div>
     <div class="icon-card-label">Puzzle</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-questionmark.svg" alt="Questionmark" />
+      <img src="/brand-icons/f5-icon-other-questionmark.svg" alt="Questionmark" />
     </div>
     <div class="icon-card-label">Questionmark</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-recycle.svg" alt="Recycle" />
+      <img src="/brand-icons/f5-icon-other-recycle.svg" alt="Recycle" />
     </div>
     <div class="icon-card-label">Recycle</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-reduced-complexity-alt.svg" alt="Reduced Complexity Alt" />
+      <img src="/brand-icons/f5-other-reduced-complexity-alt.svg" alt="Reduced Complexity Alt" />
     </div>
     <div class="icon-card-label">Reduced Complexity Alt</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-renewable-energy.svg" alt="Renewable Energy" />
+      <img src="/brand-icons/f5-other-renewable-energy.svg" alt="Renewable Energy" />
     </div>
     <div class="icon-card-label">Renewable Energy</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-report-archive.svg" alt="Report Archive" />
+      <img src="/brand-icons/f5-icon-other-report-archive.svg" alt="Report Archive" />
     </div>
     <div class="icon-card-label">Report Archive</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-return-on-investment.svg" alt="Return On Investment" />
+      <img src="/brand-icons/f5-icon-other-return-on-investment.svg" alt="Return On Investment" />
     </div>
     <div class="icon-card-label">Return On Investment</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-robotic-arm.svg" alt="Robotic Arm" />
+      <img src="/brand-icons/f5-icon-other-robotic-arm.svg" alt="Robotic Arm" />
     </div>
     <div class="icon-card-label">Robotic Arm</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-rocket-deploy.svg" alt="Rocket Deploy" />
+      <img src="/brand-icons/f5-icon-other-rocket-deploy.svg" alt="Rocket Deploy" />
     </div>
     <div class="icon-card-label">Rocket Deploy</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-sad.svg" alt="Sad" />
+      <img src="/brand-icons/f5-icon-other-sad.svg" alt="Sad" />
     </div>
     <div class="icon-card-label">Sad</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-shopping-cart.svg" alt="Shopping Cart" />
+      <img src="/brand-icons/f5-icon-other-shopping-cart.svg" alt="Shopping Cart" />
     </div>
     <div class="icon-card-label">Shopping Cart</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-shopping-cart-arrow.svg" alt="Shopping Cart Arrow" />
+      <img src="/brand-icons/f5-icon-other-shopping-cart-arrow.svg" alt="Shopping Cart Arrow" />
     </div>
     <div class="icon-card-label">Shopping Cart Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-simplicity-scale-circles.svg" alt="Simplicity Scale Circles" />
+      <img src="/brand-icons/f5-other-simplicity-scale-circles.svg" alt="Simplicity Scale Circles" />
     </div>
     <div class="icon-card-label">Simplicity Scale Circles</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-simplify.svg" alt="Simplify" />
+      <img src="/brand-icons/f5-icon-other-simplify.svg" alt="Simplify" />
     </div>
     <div class="icon-card-label">Simplify</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-arrow-rotating-arrows.svg" alt="Site Arrow Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-other-site-arrow-rotating-arrows.svg" alt="Site Arrow Rotating Arrows" />
     </div>
     <div class="icon-card-label">Site Arrow Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-clock-rotating-arrows.svg" alt="Site Clock Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-other-site-clock-rotating-arrows.svg" alt="Site Clock Rotating Arrows" />
     </div>
     <div class="icon-card-label">Site Clock Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-code.svg" alt="Site Code" />
+      <img src="/brand-icons/f5-icon-other-site-code.svg" alt="Site Code" />
     </div>
     <div class="icon-card-label">Site Code</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-dashboard.svg" alt="Site Dashboard" />
+      <img src="/brand-icons/f5-icon-other-site-dashboard.svg" alt="Site Dashboard" />
     </div>
     <div class="icon-card-label">Site Dashboard</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-data-insights-magnifying-glass.svg" alt="Site Data Insights Magnifying Glass" />
+      <img src="/brand-icons/f5-icon-other-site-data-insights-magnifying-glass.svg" alt="Site Data Insights Magnifying Glass" />
     </div>
     <div class="icon-card-label">Site Data Insights Magnifying Glass</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-graphs.svg" alt="Site Graphs" />
+      <img src="/brand-icons/f5-icon-other-site-graphs.svg" alt="Site Graphs" />
     </div>
     <div class="icon-card-label">Site Graphs</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-health-magnifying-glass.svg" alt="Site Health Magnifying Glass" />
+      <img src="/brand-icons/f5-icon-other-site-health-magnifying-glass.svg" alt="Site Health Magnifying Glass" />
     </div>
     <div class="icon-card-label">Site Health Magnifying Glass</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-metrics.svg" alt="Site Metrics" />
+      <img src="/brand-icons/f5-icon-other-site-metrics.svg" alt="Site Metrics" />
     </div>
     <div class="icon-card-label">Site Metrics</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-metrics-magnifying-glass.svg" alt="Site Metrics Magnifying Glass" />
+      <img src="/brand-icons/f5-icon-other-site-metrics-magnifying-glass.svg" alt="Site Metrics Magnifying Glass" />
     </div>
     <div class="icon-card-label">Site Metrics Magnifying Glass</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-network.svg" alt="Site Network" />
+      <img src="/brand-icons/f5-icon-other-site-network.svg" alt="Site Network" />
     </div>
     <div class="icon-card-label">Site Network</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-site-user-rotating-arrows.svg" alt="Site User Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-other-site-user-rotating-arrows.svg" alt="Site User Rotating Arrows" />
     </div>
     <div class="icon-card-label">Site User Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-star.svg" alt="Star" />
+      <img src="/brand-icons/f5-icon-other-star.svg" alt="Star" />
     </div>
     <div class="icon-card-label">Star</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-stopwatch.svg" alt="Stopwatch" />
+      <img src="/brand-icons/f5-icon-other-stopwatch.svg" alt="Stopwatch" />
     </div>
     <div class="icon-card-label">Stopwatch</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-strategy.svg" alt="Strategy" />
+      <img src="/brand-icons/f5-icon-other-strategy.svg" alt="Strategy" />
     </div>
     <div class="icon-card-label">Strategy</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-syringe.svg" alt="Syringe" />
+      <img src="/brand-icons/f5-icon-other-syringe.svg" alt="Syringe" />
     </div>
     <div class="icon-card-label">Syringe</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-target.svg" alt="Target" />
+      <img src="/brand-icons/f5-icon-other-target.svg" alt="Target" />
     </div>
     <div class="icon-card-label">Target</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-tech-brain.svg" alt="Tech Brain" />
+      <img src="/brand-icons/f5-icon-other-tech-brain.svg" alt="Tech Brain" />
     </div>
     <div class="icon-card-label">Tech Brain</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-tech-brain-gear.svg" alt="Tech Brain Gear" />
+      <img src="/brand-icons/f5-icon-other-tech-brain-gear.svg" alt="Tech Brain Gear" />
     </div>
     <div class="icon-card-label">Tech Brain Gear</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-tech-brain-rotating-arrows.svg" alt="Tech Brain Rotating Arrows" />
+      <img src="/brand-icons/f5-icon-other-tech-brain-rotating-arrows.svg" alt="Tech Brain Rotating Arrows" />
     </div>
     <div class="icon-card-label">Tech Brain Rotating Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-tech-brain-secure-ai.svg" alt="Tech Brain Secure Ai" />
+      <img src="/brand-icons/f5-icon-other-tech-brain-secure-ai.svg" alt="Tech Brain Secure Ai" />
     </div>
     <div class="icon-card-label">Tech Brain Secure Ai</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-tech-brain-unsecure-ai.svg" alt="Tech Brain Unsecure Ai" />
+      <img src="/brand-icons/f5-icon-other-tech-brain-unsecure-ai.svg" alt="Tech Brain Unsecure Ai" />
     </div>
     <div class="icon-card-label">Tech Brain Unsecure Ai</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-telescope.svg" alt="Telescope" />
+      <img src="/brand-icons/f5-icon-other-telescope.svg" alt="Telescope" />
     </div>
     <div class="icon-card-label">Telescope</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-thought-bubble.svg" alt="Thought Bubble" />
+      <img src="/brand-icons/f5-icon-other-thought-bubble.svg" alt="Thought Bubble" />
     </div>
     <div class="icon-card-label">Thought Bubble</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-thumbs-down.svg" alt="Thumbs Down" />
+      <img src="/brand-icons/f5-icon-other-thumbs-down.svg" alt="Thumbs Down" />
     </div>
     <div class="icon-card-label">Thumbs Down</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-thumbs-up.svg" alt="Thumbs Up" />
+      <img src="/brand-icons/f5-icon-other-thumbs-up.svg" alt="Thumbs Up" />
     </div>
     <div class="icon-card-label">Thumbs Up</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-tool-wrench.svg" alt="Tool Wrench" />
+      <img src="/brand-icons/f5-icon-other-tool-wrench.svg" alt="Tool Wrench" />
     </div>
     <div class="icon-card-label">Tool Wrench</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-tools.svg" alt="Tools" />
+      <img src="/brand-icons/f5-icon-other-tools.svg" alt="Tools" />
     </div>
     <div class="icon-card-label">Tools</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-troll.svg" alt="Troll" />
+      <img src="/brand-icons/f5-icon-other-troll.svg" alt="Troll" />
     </div>
     <div class="icon-card-label">Troll</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-upgrade.svg" alt="Upgrade" />
+      <img src="/brand-icons/f5-icon-other-upgrade.svg" alt="Upgrade" />
     </div>
     <div class="icon-card-label">Upgrade</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-us-currency-3arrows.svg" alt="Us Currency 3Arrows" />
+      <img src="/brand-icons/f5-icon-other-us-currency-3arrows.svg" alt="Us Currency 3Arrows" />
     </div>
     <div class="icon-card-label">Us Currency 3Arrows</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-us-currency-down-arrow.svg" alt="Us Currency Down Arrow" />
+      <img src="/brand-icons/f5-icon-other-us-currency-down-arrow.svg" alt="Us Currency Down Arrow" />
     </div>
     <div class="icon-card-label">Us Currency Down Arrow</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-very-positive-performance.svg" alt="Very Positive Performance" />
+      <img src="/brand-icons/f5-icon-other-very-positive-performance.svg" alt="Very Positive Performance" />
     </div>
     <div class="icon-card-label">Very Positive Performance</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-visibility-eye.svg" alt="Visibility Eye" />
+      <img src="/brand-icons/f5-icon-other-visibility-eye.svg" alt="Visibility Eye" />
     </div>
     <div class="icon-card-label">Visibility Eye</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-voice-talk.svg" alt="Voice Talk" />
+      <img src="/brand-icons/f5-icon-other-voice-talk.svg" alt="Voice Talk" />
     </div>
     <div class="icon-card-label">Voice Talk</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-warning.svg" alt="Warning" />
+      <img src="/brand-icons/f5-icon-other-warning.svg" alt="Warning" />
     </div>
     <div class="icon-card-label">Warning</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-other-weight-technical-debt.svg" alt="Weight Technical Debt" />
+      <img src="/brand-icons/f5-other-weight-technical-debt.svg" alt="Weight Technical Debt" />
     </div>
     <div class="icon-card-label">Weight Technical Debt</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image">
-      <img src="./f5-icon-other-yen-currency-down-arrow.svg" alt="Yen Currency Down Arrow" />
+      <img src="/brand-icons/f5-icon-other-yen-currency-down-arrow.svg" alt="Yen Currency Down Arrow" />
     </div>
     <div class="icon-card-label">Yen Currency Down Arrow</div>
   </div>


### PR DESCRIPTION
## Summary
- Changed all 665 `<img src="./f5-*.svg">` to `<img src="/brand-icons/f5-*.svg">` in `docs/06-brand-icons.mdx`
- The relative `./` prefix resolved from the page URL `/06-brand-icons/` to incorrect paths like `/06-brand-icons/f5-icon-*.svg`
- The CI workflow mounts `docs/brand-icons/` at `/app/public/brand-icons/`, so the correct root-relative path is `/brand-icons/`
- Confirmed broken on the live site: SVG images return 404

Closes #241

## Test plan
- [ ] CI passes
- [ ] After merge, verify brand-icons page at https://robinmordasiewicz.github.io/f5xc-docs-theme/06-brand-icons/ loads SVG images correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)